### PR TITLE
Generate inter-artifact dependencies in the bazel BUILD files.

### DIFF
--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -15,7 +15,9 @@
 #   A repository rule intended to be used in populating @maven_repository.
 #
 load(":sets.bzl", "sets")
+load(":utils.bzl", "strings", "paths")
 load(":artifacts.bzl", "artifacts")
+load(":poms.bzl", "poms")
 
 _DOWNLOAD_PREFIX = "maven"
 
@@ -65,8 +67,45 @@ load("@{maven_rules_repository}//maven:maven.bzl", "maven_jvm_artifact")
 _MAVEN_REPO_TARGET_TEMPLATE = """maven_jvm_artifact(
     name = "{target}",
     artifact = "{artifact_coordinates}",
+    deps = [{deps}
+    ]
 )
 """
+_POM_XPATH_DEPENDENCIES_QUERY = """/project/dependencies/dependency[not(scope) or scope/text()="compile"]"""
+
+
+def _get_dependency_fragment(ctx, pom_file):
+    pom_file_no_xmlns = "%s.noxmlns" % pom_file
+    result = ctx.execute(["sed" , "-e", "s/xmlns=/xmlns:ignore=/", pom_file])
+    ctx.file(pom_file_no_xmlns, result.stdout)
+    result = ctx.execute(["xmllint" , pom_file_no_xmlns, "--xpath", _POM_XPATH_DEPENDENCIES_QUERY])
+    if bool(result.stderr):
+        if strings.contains(result.stderr, "empty"):
+            pass # It's ok if we receive an empty result.
+        else:
+            fail("Parsing poms failed for %s with error: %s" % (paths.filename(pom_file), result.stderr))
+    return result.stdout
+
+def _convert_maven_dep(repo_name, artifact):
+    group_path = artifact.group_id.replace(".", "/")
+    if paths.filename(group_path) == artifact.artifact_id:
+        return "@{repo}//{group_path}".format(repo = repo_name, group_path = group_path)
+    else:
+        target = artifacts.munge_target(artifact.artifact_id)
+        return "@{repo}//{group_path}:{target}".format(repo = repo_name, group_path = group_path, target = target)
+
+def _get_dependencies_from_pom_files(ctx, artifact, group_path):
+    pom_urls = ["%s/%s" % (repo, artifact.pom) for repo in ctx.attr.repository_urls]
+    pom_file = "%s/%s-%s.pom" % (group_path, artifact.artifact_id, artifact.version)
+    ctx.download(url = pom_urls, output = pom_file)
+    output = _get_dependency_fragment(ctx, pom_file)
+    tidy_xml = "".join([strings.trim(x) for x in strings.trim(output).splitlines()])
+    maven_deps = poms.extract_dependencies(tidy_xml)
+    return maven_deps
+
+def _deps_string(bazel_deps):
+    bazel_deps = ["""        "%s",""" % x for x in bazel_deps]
+    return "\n%s" % "\n".join(bazel_deps) if bool(bazel_deps) else ""
 
 def _generate_maven_repository_impl(ctx):
     # Generate the root WORKSPACE file
@@ -75,6 +114,11 @@ def _generate_maven_repository_impl(ctx):
 
     # Generate the per-group_id BUILD files.
     build_substitutes = ctx.attr.build_substitutes
+    processed_artifacts = sets.new()
+    for specs in ctx.attr.grouped_artifacts.values():
+        artifact_structs = [artifacts.parse_spec(s) for s in specs]
+        sets.add_all(processed_artifacts, ["%s:%s" % (a.group_id, a.artifact_id) for a in artifact_structs])
+    build_files = {}
     for group_id, specs in ctx.attr.grouped_artifacts.items():
         ctx.report_progress("Generating build details for artifacts in %s" % group_id)
         specs = sets.add_all(sets.new(), specs)
@@ -84,24 +128,42 @@ def _generate_maven_repository_impl(ctx):
         group_path = group_id.replace(".", "/")
         for spec in specs:
             artifact = artifacts.annotate(artifacts.parse_spec(spec))
+            coordinates = "%s:%s" % (artifact.group_id, artifact.artifact_id)
+            sets.add(processed_artifacts, coordinates)
+            maven_deps = _get_dependencies_from_pom_files(ctx, artifact, group_path)
+            found_artifacts = {}
+            bazel_deps = []
+            for dep in maven_deps:
+                found_artifacts[dep.coordinate] = dep
+                bazel_deps += [_convert_maven_dep(ctx.attr.name, dep)]
+            unregistered = sets.difference(sets.add_all(sets.new(), found_artifacts), processed_artifacts)
+            if bool(unregistered) and not bool(build_substitutes.get(coordinates)):
+                unregistered_deps = [poms.format(x) for x in maven_deps if sets.contains(unregistered, x.coordinate)]
+                fail("Some dependencies of %s were not pinned in the artifacts list:\n%s" % (
+                    spec,
+                    list(unregistered_deps),
+                ))
             target_definitions += [
                 build_substitutes.get(
-                    "%s:%s" % (artifact.group_id, artifact.artifact_id),
+                    coordinates,
                     _MAVEN_REPO_TARGET_TEMPLATE.format(
                         target = artifact.third_party_target_name,
+                        deps = _deps_string(bazel_deps),
                         artifact_coordinates = artifact.original_spec,
                     )
                 )
             ]
-        ctx.file(
-            "%s/BUILD" % group_path,
-            "\n".join([prefix] + target_definitions),
-        )
+        file = "%s/BUILD" % group_path
+        content = "\n".join([prefix] + target_definitions)
+        ctx.file(file, content)
+        # build_files[build_file] = build_content
+
 
 _generate_maven_repository = repository_rule(
     implementation = _generate_maven_repository_impl,
     attrs = {
         "grouped_artifacts": attr.string_list_dict(mandatory = True),
+        "repository_urls": attr.string_list(mandatory = True),
         "maven_rules_repository": attr.string(mandatory = False, default = "maven_repository_rules"),
         "build_substitutes": attr.string_dict(mandatory = True),
     },
@@ -192,6 +254,7 @@ def _maven_repository_specification(
     _generate_maven_repository(
         name = name,
         grouped_artifacts = grouped_artifacts,
+        repository_urls = repository_urls,
         build_substitutes = build_substitutes,
     )
 

--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -1,0 +1,92 @@
+#
+# Description:
+#   Utilities for extracting information from pom files.
+#
+load(":utils.bzl", "strings")
+
+_maven_dep_properties = ["artifactId", "groupId", "version", "type", "scope", "optional", "classifier", "systemPath"]
+
+def _parse_fragment(deps_fragment):
+    for property in _maven_dep_properties:
+        deps_fragment = deps_fragment.replace("</%s>" % property, "::")
+        deps_fragment = deps_fragment.replace("<%s>" % property, "%s:" % property)
+    group_id = None
+    artifact_id = None
+    version = "INFERRED"
+    type = "jar"
+    optional = False
+    scope = "compile"
+    classifier = None
+    system_path = None
+
+    for fragment_element in deps_fragment.split("::"):
+        if not bool(fragment_element):
+            continue
+        key, token = fragment_element.split(":")
+        if strings.contains(token, "$"):
+            token = "INFERRED" # TODO(cgruber) handle property substitution.
+            # _substitute_variable(string, variable_key, value)
+        if key == "groupId":
+            group_id = token
+        elif key == "artifactId":
+            artifact_id = token
+        elif key == "version":
+            version = token
+        elif key == "classifier":
+            classifier = token
+        elif key == "type":
+            type = token
+        elif key == "scope":
+            scope = token
+        elif key == "optional":
+            optional = bool(token)
+        elif key == "systemPath":
+            systemPath = token
+
+    return struct(
+        group_id = group_id,
+        artifact_id = artifact_id,
+        version = version,
+        type = "jar",
+        optional = False,
+        scope = "compile",
+        classifier = None,
+        system_path = None,
+        coordinate = "%s:%s" % (group_id, artifact_id)
+    )
+
+def _parse_fragments(deps_fragments):
+    deps = []
+    for deps_fragment in deps_fragments:
+        deps += [_parse_fragment(deps_fragment)]
+    return deps
+
+# extracts dependency coordinates from a given <dependency> section of a pom file.  This only handles
+# a repeated set of <dependency> sections, without a parent element.
+def _extract_dependencies(xml_fragment):
+    if not bool(xml_fragment):
+        return []
+
+    # Trim start and end elements.
+    if xml_fragment.startswith("<dependency>"):
+        xml_fragment = xml_fragment[len("<dependency>"):-len("</dependency>")]
+    else:
+        fail("Invalid maven dependency xml fragment.  Please file an issue: %s" % xml_fragment)
+    deps_fragments = xml_fragment.split("</dependency><dependency>")
+    deps = _parse_fragments(deps_fragments)
+    return deps
+
+def _format(dep):
+    result = "%s:%s:%s" % (dep.group_id, dep.artifact_id, dep.version)
+    if bool(dep.classifier):
+        type = dep.type if bool(dep.type) else "jar"
+        result = "%s:%s" % (result, dep.type)
+    else:
+        if bool(dep.type) and not dep.type == "jar":
+            result = "%s:%s" % (result, dep.type)
+    return result
+
+poms = struct(
+    extract_dependencies = _extract_dependencies,
+    format = _format,
+)

--- a/maven/sets.bzl
+++ b/maven/sets.bzl
@@ -15,11 +15,17 @@ def _add(set_dict, item):
     set_dict[item] = _EMPTY
     return set_dict
 
-
 def _add_all(set_dict, items):
     """Adds all items to the set and returns the set"""
-    for item in items:
-        _add(set_dict, item)
+    item_type = type(items)
+    if item_type == type({}):
+        for item in items.keys():
+            _add(set_dict, item)
+    elif item_type == type([]):
+        for item in items:
+            _add(set_dict, item)
+    else:
+        fail("Error, invalid %s argument passed to set operation." % item_type)
     return set_dict
 
 def _pop(set_dict):
@@ -31,8 +37,20 @@ def _new():
     """Creates a new set.  Not strictly necessary, since a dict can be passed, but it's more """
     return {}
 
+def _difference(set_dict1, set_dict2):
+    """Returns the elements that reflect the set difference (items in set_dict2 that are not in set_dict1)"""
+    return sets.add_all(sets.new(), [x for x in set_dict1 if not sets.contains(set_dict2, x)])
+
+def _disjunctive_union(set_dict1, set_dict2):
+    """Returns a set containing all the elements in the supplied sets are not contained in both sets."""
+    result = sets.new()
+    sets.add_all(result, sets.difference(set_dict1, set_dict2))
+    sets.add_all(result, sets.difference(set_dict2, set_dict1))
+    return result
 
 sets = struct(
+    difference = _difference,
+    disjunctive_union = _disjunctive_union,
     contains = _contains,
     add = _add,
     add_all = _add_all,

--- a/maven/sets.bzl
+++ b/maven/sets.bzl
@@ -41,16 +41,8 @@ def _difference(set_dict1, set_dict2):
     """Returns the elements that reflect the set difference (items in set_dict2 that are not in set_dict1)"""
     return sets.add_all(sets.new(), [x for x in set_dict1 if not sets.contains(set_dict2, x)])
 
-def _disjunctive_union(set_dict1, set_dict2):
-    """Returns a set containing all the elements in the supplied sets are not contained in both sets."""
-    result = sets.new()
-    sets.add_all(result, sets.difference(set_dict1, set_dict2))
-    sets.add_all(result, sets.difference(set_dict2, set_dict1))
-    return result
-
 sets = struct(
     difference = _difference,
-    disjunctive_union = _disjunctive_union,
     contains = _contains,
     add = _add,
     add_all = _add_all,

--- a/maven/utils.bzl
+++ b/maven/utils.bzl
@@ -1,0 +1,25 @@
+#
+# Description:
+#   Common utilities to make code a little cleaner.
+#
+
+# Performs a typical "trim()" operation on a string, eliminating whitespace (or optionally supplied characters) from
+# the front and back of the string.
+def _trim(string, characters = "\n "):
+    return string.strip(characters)
+
+def _contains(string, substring):
+    return not (string.find(substring) == -1)
+
+strings = struct(
+    contains = _contains,
+    trim = _trim,
+)
+
+def _filename(string):
+    (path, sep, file) = string.rpartition("/")
+    return file if bool(sep) else string
+
+paths = struct(
+    filename = _filename
+)

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -3,7 +3,14 @@ workspace(name = "test_workspace")
 # Set up maven
 local_repository(name = "maven_repository_rules", path = "../..")
 load("@maven_repository_rules//maven:maven.bzl", "maven_repository_specification")
-load(":build_substitution_templates.bzl", "DAGGER_PLUGIN_BUILD_SUBSTITUTE")
+load(
+    ":build_substitution_templates.bzl",
+    "DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN",
+    "DAGGER_COMPILER_BUILD_SUBSTITUTE",
+    "DAGGER_PRODUCERS_BUILD_SUBSTITUTE",
+    "DAGGER_SPI_BUILD_SUBSTITUTE",
+    "GOOGLE_JAVA_FORMAT_BUILD_SUBSTITUTE",
+)
 
 maven_repository_specification(
     name = "maven",
@@ -20,11 +27,26 @@ maven_repository_specification(
         "javax.annotation:jsr250-api:1.0",
         "javax.inject:javax.inject:1",
         "junit:junit:4.13-beta-1",
+        "com.google.errorprone:error_prone_annotations:2.1.3",
+        "com.google.j2objc:j2objc-annotations:1.1",
+        "org.codehaus.mojo:animal-sniffer-annotations:1.14",
+        "org.hamcrest:hamcrest-core:1.3",
     ],
     artifacts = {
         "com.google.guava:guava:25.0-jre": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9",
     },
     build_substitutes = {
-        "com.google.dagger:dagger": DAGGER_PLUGIN_BUILD_SUBSTITUTE.format(dagger_version = "2.20", repo = "maven"),
+        # Because we rewrite the core dagger target, upon which other dagger impl packages depend, including the
+        # java_plugin which in turn depends on those, this creates a build cycle.  So we replace the dagger bits with
+        # updated deps list, instead of relying on the targets inferred from pom metadata.  These sorts of interventions
+        # should be fairly rare in the deps graph, as only things like annotation processors need this sort of wrapped
+        # intervention.
+        #
+        # TODO(cgruber) provide a more precise and terse option of BUILD surgery.
+        "com.google.dagger:dagger": DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN.format(dagger_version = "2.20"),
+        "com.google.dagger:dagger-compiler": DAGGER_COMPILER_BUILD_SUBSTITUTE.format(dagger_version = "2.20"),
+        "com.google.dagger:dagger-producers": DAGGER_PRODUCERS_BUILD_SUBSTITUTE.format(dagger_version = "2.20"),
+        "com.google.dagger:dagger-spi": DAGGER_SPI_BUILD_SUBSTITUTE.format(dagger_version = "2.20"),
+        "com.google.googlejavaformat:google-java-format": GOOGLE_JAVA_FORMAT_BUILD_SUBSTITUTE,
     }
 )

--- a/test/test_workspace/build_substitution_templates.bzl
+++ b/test/test_workspace/build_substitution_templates.bzl
@@ -18,46 +18,101 @@
 #   maven_repository_specification(
 #       ...
 #       build_substitutes = {
-#           "com.google.dagger:dagger": DAGGER_PLUGIN_BUILD_SUBSTITUTE.format(dagger_version = "2.20", repo = "maven"),
+#           "com.google.dagger:dagger": DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN.format(dagger_version = "2.20"),
 #       }
 #   )
 #
-# Note:
-#   This set of internal dependencies is valid as of dagger 2.20. Other versions may require different deps.
-#
-DAGGER_PLUGIN_BUILD_SUBSTITUTE = """
+DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN = """
 java_library(
-    name = "dagger",
-    exports = [
-        ":dagger_api",
-        "@maven//javax/inject:javax_inject",
-    ],
-    exported_plugins = [":dagger_plugin"],
-    visibility = ["//visibility:public"],
+   name = "dagger",
+   exports = [
+       ":dagger_api",
+       "@maven//javax/inject:javax_inject",
+   ],
+   exported_plugins = [":dagger_plugin"],
+   visibility = ["//visibility:public"],
 )
 
 maven_jvm_artifact(
-    name = "dagger_api",
-    artifact = "com.google.dagger:dagger:{dagger_version}",
+   name = "dagger_api",
+   artifact = "com.google.dagger:dagger:{dagger_version}",
 )
 
 java_plugin(
-    name = "dagger_plugin",
-    processor_class = "dagger.internal.codegen.ComponentProcessor",
-    generates_api = True,
+   name = "dagger_plugin",
+   processor_class = "dagger.internal.codegen.ComponentProcessor",
+   generates_api = True,
+   deps = [":dagger_compiler"],
+)
+"""
+
+# Description:
+#   Replaces the naive dagger-compiler BUILD file, because we rewrite dagger -> dagger_api above, and the naive deps
+#   list for dagger-compiler would result in a build cycle (since it would depend on :dagger).
+#
+DAGGER_COMPILER_BUILD_SUBSTITUTE = """
+maven_jvm_artifact(
+    name = "dagger_compiler",
+    artifact = "com.google.dagger:dagger-compiler:{dagger_version}",
     deps = [
         ":dagger_api",
-        ":dagger_compiler",
         ":dagger_producers",
         ":dagger_spi",
-        "@{repo}//com/google/code/findbugs:jsr305",
-        "@{repo}//com/google/errorprone:javac_shaded",
-        "@{repo}//com/google/googlejavaformat:google_java_format",
-        "@{repo}//com/google/guava",
-        "@{repo}//com/squareup:javapoet",
-        "@{repo}//org/checkerframework:checker_compat_qual",
-        "@{repo}//javax/annotation:jsr250_api",
-        "@{repo}//javax/inject:javax_inject",
+        "@maven//com/google/googlejavaformat:google_java_format",
+        "@maven//com/google/guava:guava",
+        "@maven//com/squareup:javapoet",
+        "@maven//javax/annotation:jsr250_api",
+        "@maven//javax/inject:javax_inject",
+    ]
+)
+"""
+
+# Description:
+#   Replaces the naive dagger-producers BUILD file, because we rewrite dagger -> dagger_api above, and the naive deps
+#   list for dagger-producers would result in a build cycle (since it would depend on :dagger).
+#
+DAGGER_PRODUCERS_BUILD_SUBSTITUTE = """
+maven_jvm_artifact(
+    name = "dagger_producers",
+    artifact = "com.google.dagger:dagger-producers:{dagger_version}",
+    deps = [
+        ":dagger_api",
+        "@maven//com/google/guava:guava",
+        "@maven//javax/inject:javax_inject",
+        "@maven//org/checkerframework:checker_compat_qual",
+    ]
+)
+"""
+
+# Description:
+#   Replaces the naive dagger-producers BUILD file, because we rewrite dagger -> dagger_api above, and the naive deps
+#   list for dagger-producers would result in a build cycle (since it would depend on :dagger).
+#
+DAGGER_SPI_BUILD_SUBSTITUTE = """
+maven_jvm_artifact(
+    name = "dagger_spi",
+    artifact = "com.google.dagger:dagger-spi:{dagger_version}",
+    deps = [
+        ":dagger_api",
+        ":dagger_producers",
+        "@maven//com/google/guava:guava",
+        "@maven//javax/inject:javax_inject",
+    ]
+)
+"""
+
+# Description:
+#   Substitute this since the naive reading of the .pom doesn't properly list some dependencies as test-only.
+#   This shouldn't be necessary once property-substitution and parent-pom integration are supported.
+GOOGLE_JAVA_FORMAT_BUILD_SUBSTITUTE = """
+maven_jvm_artifact(
+    name = "google_java_format",
+    artifact = "com.google.googlejavaformat:google-java-format:1.6",
+    deps = [
+        "@maven//com/google/guava",
+        "@maven//com/google/errorprone:javac_shaded",
+        "@maven//com/google/code/findbugs:jsr305",
+        "@maven//com/google/errorprone:error_prone_annotations",
     ],
 )
 """


### PR DESCRIPTION
Generate inter-artifact dependencies in the bazel BUILD files, inferred from their .pom files' metadata.  These all resolve through the same specified repository, so interactions between multiple `maven_repository_specification` declarations will need to be manually inserted via the `build_substitutions` mechanism, if relevant.

Fixes #4 

It's worth noting that this PR increases the configuration burden for doing things like wrapping dagger with an exported_plugins attributed wrapper rule, because doing so introduces build cycles in the dependency relationships inferred from the pom files.  This is addressable (verbosely) using the build_substitution mechanism, but a more supple mechanism (e.g. #9) will be needed to reduce the verbosity.  The trade-off here is that every other artifact gets its bazel representation set up with its (compile/runtime) dependencies automatically, and so the bazel workspace deps graph will reflect the real graph (modulo version pinning).

Also, the Dagger example in the test is going to be one of the most verbose, and so one should expect that as the artifacts list grows, the use of build_substitutions should not grow linearly with it, so this verbosity and complexity due to mangling dagger's deps graph should be amortized over the simplicity of the other targets (and having their deps automatically generated).

The other deficiency with this version is that it doesn't take into account versions specified by properties statements, or implicitly in dependencyManagement sections or inherited from parents.  This only impacts error messages, but should be addressed (see #7) eventually. 

