### PR TITLE
Surgical dependency target rewriting

### DIFF
--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -94,11 +94,7 @@ def _normalize_target(full_target_spec, current_package, target_substitutions):
     local_package = full_package.split("//")[1] # @maven//blah/foo -> blah/foo
     if local_package == current_package:
         return ":%s" % target # Trim to a local reference.
-    else:
-        if paths.filename(full_package) == target:
-            return full_package
-        else:
-            return full_target_spec
+    return full_package if paths.filename(full_package) == target else full_target_spec
 
 def _get_dependencies_from_pom_files(ctx, artifact, group_path):
     pom_urls = ["%s/%s" % (repo, artifact.pom) for repo in ctx.attr.repository_urls]

--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -15,7 +15,7 @@
 #   A repository rule intended to be used in populating @maven_repository.
 #
 load(":sets.bzl", "sets")
-load(":utils.bzl", "strings", "paths")
+load(":utils.bzl", "strings", "paths", "dicts")
 load(":artifacts.bzl", "artifacts")
 load(":poms.bzl", "poms")
 
@@ -69,11 +69,8 @@ load("@{maven_rules_repository}//maven:maven.bzl", "maven_jvm_artifact")
 _MAVEN_REPO_TARGET_TEMPLATE = """maven_jvm_artifact(
     name = "{target}",
     artifact = "{artifact_coordinates}",
-    deps = [{deps}
-    ]
-)
+{deps})
 """
-
 def _get_dependency_fragment(ctx, pom_file):
     pom_file_no_xmlns = "%s.noxmlns" % pom_file
     result = ctx.execute(["sed" , "-e", "s/xmlns=/xmlns:ignore=/", pom_file])
@@ -88,11 +85,20 @@ def _get_dependency_fragment(ctx, pom_file):
 
 def _convert_maven_dep(repo_name, artifact):
     group_path = artifact.group_id.replace(".", "/")
-    if paths.filename(group_path) == artifact.artifact_id:
-        return "@{repo}//{group_path}".format(repo = repo_name, group_path = group_path)
+    target = artifacts.munge_target(artifact.artifact_id)
+    return "@{repo}//{group_path}:{target}".format(repo = repo_name, group_path = group_path, target = target)
+
+def _normalize_target(full_target_spec, current_package, target_substitutions):
+    full_target_spec = target_substitutions.get(full_target_spec, full_target_spec)
+    full_package, target = full_target_spec.split(":")
+    local_package = full_package.split("//")[1] # @maven//blah/foo -> blah/foo
+    if local_package == current_package:
+        return ":%s" % target # Trim to a local reference.
     else:
-        target = artifacts.munge_target(artifact.artifact_id)
-        return "@{repo}//{group_path}:{target}".format(repo = repo_name, group_path = group_path, target = target)
+        if paths.filename(full_package) == target:
+            return full_package
+        else:
+            return full_target_spec
 
 def _get_dependencies_from_pom_files(ctx, artifact, group_path):
     pom_urls = ["%s/%s" % (repo, artifact.pom) for repo in ctx.attr.repository_urls]
@@ -104,9 +110,10 @@ def _get_dependencies_from_pom_files(ctx, artifact, group_path):
     return maven_deps
 
 def _deps_string(bazel_deps):
+    if not bool(bazel_deps):
+        return ""
     bazel_deps = ["""        "%s",""" % x for x in bazel_deps]
-    return "\n%s" % "\n".join(bazel_deps) if bool(bazel_deps) else ""
-
+    return "    deps = [\n%s\n    ]\n" % "\n".join(bazel_deps) if bool(bazel_deps) else ""
 
 def _generate_maven_repository_impl(ctx):
     # Generate the root WORKSPACE file
@@ -115,18 +122,21 @@ def _generate_maven_repository_impl(ctx):
 
     # Generate the per-group_id BUILD files.
     build_substitutes = ctx.attr.build_substitutes
+    target_substitutes = dicts.decode_nested(ctx.attr.target_substitutes)
     processed_artifacts = sets.new()
     for specs in ctx.attr.grouped_artifacts.values():
         artifact_structs = [artifacts.parse_spec(s) for s in specs]
         sets.add_all(processed_artifacts, ["%s:%s" % (a.group_id, a.artifact_id) for a in artifact_structs])
     build_files = {}
     for group_id, specs in ctx.attr.grouped_artifacts.items():
+        package_target_substitutes = target_substitutes.get(group_id, {})
         ctx.report_progress("Generating build details for artifacts in %s" % group_id)
         specs = sets.add_all(sets.new(), specs)
         prefix = _MAVEN_REPO_BUILD_PREFIX.format(
             group_id = group_id, maven_rules_repository = ctx.attr.maven_rules_repository)
         target_definitions = []
         group_path = group_id.replace(".", "/")
+        full_package = "@%s//%s" % (ctx.attr.name, group_path)
         for spec in specs:
             artifact = artifacts.annotate(artifacts.parse_spec(spec))
             coordinates = "%s:%s" % (artifact.group_id, artifact.artifact_id)
@@ -139,6 +149,7 @@ def _generate_maven_repository_impl(ctx):
             for dep in maven_deps:
                 found_artifacts[dep.coordinate] = dep
                 bazel_deps += [_convert_maven_dep(ctx.attr.name, dep)]
+            normalized_deps = [_normalize_target(x, full_package, package_target_substitutes) for x in bazel_deps]
             unregistered = sets.difference(sets.add_all(sets.new(), found_artifacts), processed_artifacts)
             if bool(unregistered) and not bool(build_substitutes.get(coordinates)):
                 unregistered_deps = [poms.format(x) for x in maven_deps if sets.contains(unregistered, x.coordinate)]
@@ -151,7 +162,7 @@ def _generate_maven_repository_impl(ctx):
                     coordinates,
                     _MAVEN_REPO_TARGET_TEMPLATE.format(
                         target = artifact.third_party_target_name,
-                        deps = _deps_string(bazel_deps),
+                        deps = _deps_string(normalized_deps),
                         artifact_coordinates = artifact.original_spec,
                     )
                 )
@@ -168,6 +179,7 @@ _generate_maven_repository = repository_rule(
         "grouped_artifacts": attr.string_list_dict(mandatory = True),
         "repository_urls": attr.string_list(mandatory = True),
         "maven_rules_repository": attr.string(mandatory = False, default = "maven_repository_rules"),
+        "target_substitutes": attr.string_list_dict(mandatory = True),
         "build_substitutes": attr.string_dict(mandatory = True),
     },
 )
@@ -226,6 +238,7 @@ def _maven_repository_specification(
         artifact_specs = {},
         insecure_artifacts = [],
         build_substitutes = {},
+        target_substitutes = {},
         repository_urls = ["https://repo1.maven.org/maven2"]):
 
     _validate_no_insecure_artifacts(artifact_specs)
@@ -254,10 +267,16 @@ def _maven_repository_specification(
             local_path = artifact.path,
             sha256 = sha256,
         )
+
+    # Skylark rules can't take in arbitrarily deep dicts, so we rewrite dict(string->dict(string, string)) to an
+    # encoded (but trivially splittable) dict(string->list(string)).  Yes it's gross.
+    target_substitutes_rewritten = dicts.encode_nested(target_substitutes)
+
     _generate_maven_repository(
         name = name,
         grouped_artifacts = grouped_artifacts,
         repository_urls = repository_urls,
+        target_substitutes = target_substitutes_rewritten,
         build_substitutes = build_substitutes,
     )
 
@@ -282,11 +301,26 @@ def maven_jvm_artifact(artifact, name = None, deps = [], exports = [], visibilit
 #   generated `maven_jvm_artifact()` rule.
 #
 def maven_repository_specification(
+        # The name of the repository
         name,
+
+        # The dictionary of artifact:sha256 entries used to populate this repository
         artifacts = {},
+
+        # The list of artifacts (without sha256 hashes) that will be used without file hash checking.
         insecure_artifacts = [],
+
+        # The dictionary of build-file substitutions (per-target) which will replace the auto-generated target
+        # statements in the generated repository
         build_substitutes = {},
+
+        # The dictionary of per-group target substitutions.  These must be in the format:
+        # "@myreponame//path/to/package:target": "@myrepotarget//path/to/package:alternate"
+        target_substitutes = {},
+
+        # Optional list of repositories which the build rule will attempt to fetch maven artifacts and metadata.
         repository_urls = ["https://repo1.maven.org/maven2"]):
+
     # Redirected to _maven_repository_specification to allow the public parameter "artifacts" without conflicting
     # with the artifact utility struct.
     _maven_repository_specification(
@@ -294,5 +328,6 @@ def maven_repository_specification(
         artifact_specs = artifacts,
         insecure_artifacts = insecure_artifacts,
         build_substitutes = build_substitutes,
+        target_substitutes = target_substitutes,
         repository_urls = repository_urls,
     )

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -6,9 +6,6 @@ load("@maven_repository_rules//maven:maven.bzl", "maven_repository_specification
 load(
     ":build_substitution_templates.bzl",
     "DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN",
-    "DAGGER_COMPILER_BUILD_SUBSTITUTE",
-    "DAGGER_PRODUCERS_BUILD_SUBSTITUTE",
-    "DAGGER_SPI_BUILD_SUBSTITUTE",
     "GOOGLE_JAVA_FORMAT_BUILD_SUBSTITUTE",
 )
 
@@ -33,20 +30,22 @@ maven_repository_specification(
         "org.hamcrest:hamcrest-core:1.3",
     ],
     artifacts = {
+        # For illustration, most artifacts should actually be in this form, to ensure that only known .jar contents
+        # are imported into the workspace. (repository injection attacks via DNS poisoning are no fun)
         "com.google.guava:guava:25.0-jre": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9",
     },
+    target_substitutes = {
+        # Because we rewrite dagger -> dagger_spi (and make a wrapper target "dagger" that exports the dagger
+        # annotation processor) we need to rewrite the internal dependencies inside the com/google/dagger package
+        # to reflect this.
+        # "groupId": { "full bazel target": "full alternate target" }
+        "com.google.dagger": {
+            "@maven//com/google/dagger:dagger": "@maven//com/google/dagger:dagger_api",
+        },
+    },
     build_substitutes = {
-        # Because we rewrite the core dagger target, upon which other dagger impl packages depend, including the
-        # java_plugin which in turn depends on those, this creates a build cycle.  So we replace the dagger bits with
-        # updated deps list, instead of relying on the targets inferred from pom metadata.  These sorts of interventions
-        # should be fairly rare in the deps graph, as only things like annotation processors need this sort of wrapped
-        # intervention.
-        #
-        # TODO(cgruber) provide a more precise and terse option of BUILD surgery.
         "com.google.dagger:dagger": DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN.format(dagger_version = "2.20"),
-        "com.google.dagger:dagger-compiler": DAGGER_COMPILER_BUILD_SUBSTITUTE.format(dagger_version = "2.20"),
-        "com.google.dagger:dagger-producers": DAGGER_PRODUCERS_BUILD_SUBSTITUTE.format(dagger_version = "2.20"),
-        "com.google.dagger:dagger-spi": DAGGER_SPI_BUILD_SUBSTITUTE.format(dagger_version = "2.20"),
         "com.google.googlejavaformat:google-java-format": GOOGLE_JAVA_FORMAT_BUILD_SUBSTITUTE,
     }
 )
+

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -35,7 +35,7 @@ maven_repository_specification(
         "com.google.guava:guava:25.0-jre": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9",
     },
     dependency_target_substitutes = {
-        # Because we rewrite dagger -> dagger_spi (and make a wrapper target "dagger" that exports the dagger
+        # Because we rewrite dagger -> dagger_api (and make a wrapper target "dagger" that exports the dagger
         # annotation processor) we need to rewrite the internal dependencies inside the com/google/dagger package
         # to reflect this.
         # "groupId": { "full bazel target": "full alternate target" }

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -34,7 +34,7 @@ maven_repository_specification(
         # are imported into the workspace. (repository injection attacks via DNS poisoning are no fun)
         "com.google.guava:guava:25.0-jre": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9",
     },
-    target_substitutes = {
+    dependency_target_substitutes = {
         # Because we rewrite dagger -> dagger_spi (and make a wrapper target "dagger" that exports the dagger
         # annotation processor) we need to rewrite the internal dependencies inside the com/google/dagger package
         # to reflect this.

--- a/test/test_workspace/build_substitution_templates.bzl
+++ b/test/test_workspace/build_substitution_templates.bzl
@@ -47,61 +47,6 @@ java_plugin(
 """
 
 # Description:
-#   Replaces the naive dagger-compiler BUILD file, because we rewrite dagger -> dagger_api above, and the naive deps
-#   list for dagger-compiler would result in a build cycle (since it would depend on :dagger).
-#
-DAGGER_COMPILER_BUILD_SUBSTITUTE = """
-maven_jvm_artifact(
-    name = "dagger_compiler",
-    artifact = "com.google.dagger:dagger-compiler:{dagger_version}",
-    deps = [
-        ":dagger_api",
-        ":dagger_producers",
-        ":dagger_spi",
-        "@maven//com/google/googlejavaformat:google_java_format",
-        "@maven//com/google/guava:guava",
-        "@maven//com/squareup:javapoet",
-        "@maven//javax/annotation:jsr250_api",
-        "@maven//javax/inject:javax_inject",
-    ]
-)
-"""
-
-# Description:
-#   Replaces the naive dagger-producers BUILD file, because we rewrite dagger -> dagger_api above, and the naive deps
-#   list for dagger-producers would result in a build cycle (since it would depend on :dagger).
-#
-DAGGER_PRODUCERS_BUILD_SUBSTITUTE = """
-maven_jvm_artifact(
-    name = "dagger_producers",
-    artifact = "com.google.dagger:dagger-producers:{dagger_version}",
-    deps = [
-        ":dagger_api",
-        "@maven//com/google/guava:guava",
-        "@maven//javax/inject:javax_inject",
-        "@maven//org/checkerframework:checker_compat_qual",
-    ]
-)
-"""
-
-# Description:
-#   Replaces the naive dagger-producers BUILD file, because we rewrite dagger -> dagger_api above, and the naive deps
-#   list for dagger-producers would result in a build cycle (since it would depend on :dagger).
-#
-DAGGER_SPI_BUILD_SUBSTITUTE = """
-maven_jvm_artifact(
-    name = "dagger_spi",
-    artifact = "com.google.dagger:dagger-spi:{dagger_version}",
-    deps = [
-        ":dagger_api",
-        ":dagger_producers",
-        "@maven//com/google/guava:guava",
-        "@maven//javax/inject:javax_inject",
-    ]
-)
-"""
-
-# Description:
 #   Substitute this since the naive reading of the .pom doesn't properly list some dependencies as test-only.
 #   This shouldn't be necessary once property-substitution and parent-pom integration are supported.
 GOOGLE_JAVA_FORMAT_BUILD_SUBSTITUTE = """


### PR DESCRIPTION
Fix #9 by doing what it says. Introduce a mechanism to allow substitution of inferred dependency lines, so you can freely change them with `build_subtitutions` and have the rest of the package construct the correct deps graph. 