### PR TITLE
Fix handling of optional, non-compile scopes, and system_path style deps. 

### DIFF
--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -43,17 +43,18 @@ def _parse_fragment(deps_fragment):
         elif key == "systemPath":
             systemPath = token
 
-    return struct(
+    dependency_struct = struct(
         group_id = group_id,
         artifact_id = artifact_id,
         version = version,
-        type = "jar",
-        optional = False,
-        scope = "compile",
-        classifier = None,
-        system_path = None,
+        type = type,
+        optional = optional,
+        scope = scope,
+        classifier = classifier,
+        system_path = system_path,
         coordinate = "%s:%s" % (group_id, artifact_id)
     )
+    return dependency_struct
 
 def _parse_fragments(deps_fragments):
     deps = []


### PR DESCRIPTION
Extract out the logic for 'should we include this dep' into its own method, for clarity, and in the process fix the rather catastrophic set of erroneous hard-coded values that render this feature non-functional.

Fixes #17. 
