### PR TITLE
Add an XML parser, and extract the dependency information from the node tree.

### DIFF
--- a/maven/tests/all_tests.bzl
+++ b/maven/tests/all_tests.bzl
@@ -3,9 +3,10 @@ load(":paths_test.bzl", paths = "paths_test_suite")
 load(":poms_test.bzl", poms = "poms_test_suite")
 load(":sets_test.bzl", sets = "sets_test_suite")
 load(":strings_test.bzl", strings = "strings_test_suite")
+load(":xml_test.bzl", xml = "suite")
 
 def _all_tests_rule_impl(ignore):
-    for suite in [dicts, paths, poms, sets, strings]:
+    for suite in [dicts, paths, poms, sets, strings, xml]:
         suite()
 
 all_tests = rule(

--- a/maven/tests/poms_test.bzl
+++ b/maven/tests/poms_test.bzl
@@ -2,16 +2,20 @@ load(":testing.bzl", "asserts", "test_suite")
 load("//maven:poms.bzl", "poms")
 load("//maven:utils.bzl", "strings")
 
-simple_fragment = strings.trim("""
-<dependency>
-    <groupId>foo</groupId>
-    <artifactId>bar</artifactId>
-    <version>1.0</version>
-</dependency>
-""")
+SIMPLE_DEP_POM = """
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>foo</groupId>
+      <artifactId>bar</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+</project>
+"""
 
 def simple_pom_fragment_process(env):
-    deps = poms.extract_dependencies(simple_fragment)
+    deps = poms.extract_dependencies(poms.parse(SIMPLE_DEP_POM))
     asserts.equals(env, 1, len(deps))
     dep = deps[0]
     asserts.equals(env, "foo", dep.group_id)
@@ -24,36 +28,139 @@ def simple_pom_fragment_process(env):
     asserts.false(env, dep.optional)
 
 
-scoped_fragment = strings.trim("""
-<dependency>
-    <groupId>foo</groupId>
-    <artifactId>bar</artifactId>
-    <version>1.0</version>
-    <scope>test</scope>
-</dependency>
-""")
+SCOPED_DEP_POM = """
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>foo</groupId>
+      <artifactId>bar</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+"""
 
 def simple_pom_fragment_process_scope(env):
-    dep = poms.extract_dependencies(scoped_fragment)[0]
+    dep = poms.extract_dependencies(poms.parse(SCOPED_DEP_POM))[0]
     asserts.equals(env, "test", dep.scope)
 
-system_fragment = strings.trim("""
-<dependency>
-    <groupId>foo</groupId>
-    <artifactId>bar</artifactId>
-    <version>1.0</version>
-    <systemPath>/blah/foo</systemPath>
-</dependency>
-""")
+SYSTEM_PATH_POM = """
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>foo</groupId>
+      <artifactId>bar</artifactId>
+      <version>1.0</version>
+      <systemPath>/blah/foo</systemPath>
+    </dependency>
+  </dependencies>
+</project>
+"""
 
 def simple_pom_fragment_process_system_path(env):
-    dep = poms.extract_dependencies(system_fragment)[0]
+    dep = poms.extract_dependencies(poms.parse(SYSTEM_PATH_POM))[0]
     asserts.equals(env, "/blah/foo", dep.system_path)
+
+
+
+COMPLEX_POM = """
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.guava</groupId>
+    <artifactId>guava-parent</artifactId>
+    <version>25.0-jre</version>
+  </parent>
+  <artifactId>guava</artifactId>
+  <packaging>bundle</packaging>
+  <properties>
+    <!-- Properties for versions. -->
+    <animal.sniffer.version>5.0</animal.sniffer.version>
+  </properties>
+  <dependencies>
+    <!-- dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency-->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-compat-qual</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.j2objc</groupId>
+      <artifactId>j2objc-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <!-- Some random comment -->
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>animal-sniffer-annotations</artifactId>
+      <version>${animal.sniffer.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+  <foo />
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-compat-qual</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+"""
+
+
+def complex_pom_test(env):
+    project = poms.parse(COMPLEX_POM)
+    dependencies = None
+    managed_dependencies = None
+    properties = None
+    for node in project.children:
+        if node.label == "properties":
+            properties = node.children
+        elif node.label == "dependencyManagement" and len(node.children) > 0:
+            managed_dependencies = node.children[0].children
+        elif node.label == "dependencies":
+            dependencies = node.children
+
+    asserts.true(env, dependencies)
+    asserts.equals(env, 6, len(dependencies))
+
+    asserts.true(env, properties)
+    asserts.equals(env, 1, len(properties))
+
+    asserts.true(env, managed_dependencies)
+    asserts.equals(env, 2, len(managed_dependencies))
+
 
 TESTS = [
     simple_pom_fragment_process,
     simple_pom_fragment_process_scope,
     simple_pom_fragment_process_system_path,
+    complex_pom_test,
 ]
 
 # Roll-up function.

--- a/maven/tests/xml_test.bzl
+++ b/maven/tests/xml_test.bzl
@@ -1,0 +1,149 @@
+load(":testing.bzl", "asserts", "test_suite")
+load("//maven:xml.bzl", "elements", "xml", "for_testing")
+
+
+XML_FRAGMENT = """
+   <foo>
+     <bar>blah> </bar> <blah/><blah /> <blah foo=\"bar\" /></foo>
+
+"""
+
+def next_element_basic_test(env):
+    asserts.equals(env,
+        expected = struct(label = "foo", start = 4, end = 9, skipped = 4, kind = elements.kind.start, attrs = ""),
+        actual = elements.next(XML_FRAGMENT),
+        message = "First token: <foo>")
+    asserts.equals(env,
+        expected = struct(label = "bar", start = 15, end = 20, skipped = 6, kind = elements.kind.start, attrs = ""),
+        actual = elements.next(XML_FRAGMENT, 9),
+        message = "Second token: <bar>")
+    asserts.equals(env,
+        expected = struct(label = "bar", start = 26, end = 32, skipped = 6, kind = elements.kind.end, attrs = ""),
+        actual = elements.next(XML_FRAGMENT, 20),
+        message = "Third token: </bar>")
+    # same as previous, but get the preceding text.
+    token = elements.next(XML_FRAGMENT, 20)
+    asserts.equals(env,
+        expected = "blah> ",
+        actual = XML_FRAGMENT[token.start-token.skipped:token.start],
+        message = "Third token's skipped text.")
+    asserts.equals(env,
+        expected = struct(label = "blah", start = 33, end = 40, skipped = 1, kind = elements.kind.empty, attrs = ""),
+        actual = elements.next(XML_FRAGMENT, 32),
+        message = "Fourth token: <blah/>")
+    asserts.equals(env,
+        expected = struct(label = "blah", start = 40, end = 48, skipped = 0, kind = elements.kind.empty, attrs = ""),
+        actual = elements.next(XML_FRAGMENT, 40),
+        message = "Fifth token: <blah />")
+    asserts.equals(env,
+        expected = struct(label = "blah", start = 49, end = 67, skipped = 1, kind = elements.kind.empty, attrs = "foo=\"bar\""),
+        actual = elements.next(XML_FRAGMENT, 48),
+        message = "Sixth token: <blah foo=\"bar\" />")
+    asserts.equals(env,
+        expected = struct(label = "foo", start = 67, end = 73, skipped = 0, kind = elements.kind.end, attrs = ""),
+        actual = elements.next(XML_FRAGMENT, 67),
+        message = "Seventh token: </foo>")
+
+def find_element_start_test(env):
+    asserts.equals(env, 2, for_testing.find_element_start("""  <foo>""", 0))
+    asserts.equals(env, 14, for_testing.find_element_start(""" <!-- blah --><foo>""", 0))
+    asserts.equals(env, 15, for_testing.find_element_start(""" <!-- blah --> <foo>""", 0))
+    asserts.equals(env, 27, for_testing.find_element_start(""" <!-- blah --><!-- baz --> <barf />""", 0))
+    asserts.equals(env, 28, for_testing.find_element_start(""" <!-- blah --> <!-- baz --> <barf />""", 0))
+
+
+def find_element_end_test(env):
+    asserts.equals(env,
+        expected = struct(attrs = struct(end = 0, start = 0), end = 7, label = "foo"),
+        actual = for_testing.find_element_end("""  <foo>""", 2))
+    asserts.equals(env,
+        expected = struct(attrs = struct(end = 0, start = 0), end = 11, label = "foo"),
+        actual = for_testing.find_element_end("""  <foo    >""", 2))
+    asserts.equals(env,
+        expected = struct(attrs = struct(end = 17, start = 7), end = 18, label = "foo"),
+        actual = for_testing.find_element_end("""  <foo blah="foo">""", 2))
+    asserts.equals(env,
+        expected = struct(attrs = struct(end = 0, start = 0), end = 8, label = "foo"),
+        actual = for_testing.find_element_end("""  <foo/>""", 2))
+    asserts.equals(env,
+        expected = struct(attrs = struct(end = 0, start = 0), end = 9, label = "foo"),
+        actual = for_testing.find_element_end("""  <foo />""", 2))
+    asserts.equals(env,
+        expected = struct(attrs = struct(end = 18, start = 8), end = 20, label = "?xml"),
+        actual = for_testing.find_element_end("""  <?xml blah="foo"?>""", 2))
+    asserts.equals(env,
+        expected = struct(attrs = struct(end = 18, start = 8), end = 21, label = "?xml"),
+        actual = for_testing.find_element_end("""  <?xml blah="foo" ?>""", 2))
+    asserts.equals(env,
+        expected = struct(attrs = struct(end = 17, start = 7), end = 18, label = "foo"),
+        actual = for_testing.find_element_end("""  <foo blah="a>b">""", 2))
+
+
+XML_DOC = """
+<?xml version="1.0" encoding="UTF-8"  ?>
+<foo xmlns="blah"><!-- >  --><!-- another -->
+  <bar>4.0.0</bar>
+  <qof foo="blah>foo" />
+  <blah a="b">
+    <baz q="r" />
+  </blah a="b">      </foo>
+"""
+
+def finds_xml_header_test(env):
+    asserts.equals(env,
+        expected = struct(
+            label = "xml",
+            start = 1,
+            end = 41,
+            skipped = 1,
+            kind = elements.kind.xml,
+            attrs = "version=\"1.0\" encoding=\"UTF-8\""),
+        actual = elements.next(XML_DOC),
+        message = "First token: foo")
+
+def skips_comments_test(env):
+    asserts.equals(env,
+        expected = struct(
+            label = "foo", start = 42, end = 60, skipped = 1, kind = elements.kind.start, attrs = "xmlns=\"blah\""),
+        actual = elements.next(XML_DOC, 41),
+        message = "Second token: foo")
+    asserts.equals(env,
+        expected = struct(
+            label = "bar", start = 90, end = 95, skipped = 30, kind = elements.kind.start, attrs = ""),
+        actual = elements.next(XML_DOC, 60),
+        message = "Third token: bar")
+
+def greater_than_in_attribute_test(env):
+    asserts.equals(env,
+        expected = struct(
+            label = "qof", start = 109, end = 131, skipped = 3, kind = elements.kind.empty, attrs = "foo=\"blah>foo\""),
+        actual = elements.next(XML_DOC, 106),
+        message = "Fifth token: qof")
+
+def element_token_array_test(env):
+    tokens = elements.token_array(XML_DOC)
+    asserts.equals(env, 9, len(tokens))
+    asserts.equals(env,
+        expected = ["xml", "foo", "bar", "bar", "qof", "blah", "baz", "blah", "foo"],
+        actual = [x.label for x in tokens])
+
+# Mostly exercises the parser, but also confirms the root's children.
+def parse_test(env):
+    root = xml.parse(XML_DOC)
+    asserts.equals(env, 2, len(root.children))
+
+
+TESTS = [
+    next_element_basic_test,
+    find_element_start_test,
+    find_element_end_test,
+    finds_xml_header_test,
+    skips_comments_test,
+    greater_than_in_attribute_test,
+    element_token_array_test,
+    parse_test,
+]
+
+# Roll-up function.
+def suite():
+    test_suite("xml utilities", tests = TESTS)

--- a/maven/utils.bzl
+++ b/maven/utils.bzl
@@ -5,7 +5,6 @@
 
 _DICT_ENCODING_SEPARATOR = ">>>"
 
-
 # Performs a typical "trim()" operation on a string, eliminating whitespace (or optionally supplied characters) from
 # the front and back of the string.
 def _trim(string, characters = "\n "):
@@ -26,7 +25,6 @@ def _filename(string):
 paths = struct(
     filename = _filename
 )
-
 
 # Encodes a dict(string->dict(string->string)) into a dict(string->list(string)) with the string encoded so it can
 # be split and restored in decode_nested.  Skylark rules can't take in arbitrarily deep dict nesting.

--- a/maven/xml.bzl
+++ b/maven/xml.bzl
@@ -1,0 +1,267 @@
+#
+# Description:
+#   XML processing functions (e.g. tag tokenizing, etc.), including a minimal but functional parser.
+#
+load(":utils.bzl", "strings")
+
+#
+# Definitions
+#
+# element_token
+# struct(
+#   label -> the element label (e.g. "<foo>" has the label "foo")
+#   start -> the absolute start of this element token in the string, i.e. the index of "<" for this token.
+#   end -> the absolute end of the element token in the string, i.e. the index of ">" for this token.
+#   skipped -> The number of characters from the provided "start_from" substring index to the start index.
+#              e.g. for "<foo>  <bar>" the skipped for "foo" is 0, and the skipped for "bar" would be 2
+# )
+#
+#
+
+_element_kind_enum = struct(
+    start = "START",  # A start tag (e.g. "<foo>")
+    end = "END", # An end-tag (e.g. "</foo>")
+    empty = "EMPTY", # A tag without children or string content (e.g. "<blah />")
+    xml = "XML_PREFIX" # An xml prefix tag (e.g. "<?xml version="1.0" encoding="UTF-8"?>")
+)
+
+# Walks back from just before the tag end to the end of the attribute text.
+def _process_element_tail(xml, label, cursor, attr_start, tag_end):
+    for index in range(cursor-1, attr_start, -1):
+        if xml[index].isspace():
+            pass
+        else:
+            attr_end = index + 1 # end is just after the last character of the
+            return struct(
+                label = label,
+                end = tag_end,
+                attrs = struct(start = attr_start, end = attr_end))
+
+# Description:
+#   Scans the string until a ">" character is found that is not within quotes, and returns a structure with the
+#   label of the tag, the start and end indicies of the attributes section if any, and the tag end.
+#   If an xml string passed in runs out of characters before terminating the tag, the code will throw an index
+#   out of bounds error.
+def _find_element_end(xml, tag_start_index):
+    label_start = tag_start_index+1
+    if xml[tag_start_index:label_start] != "<":
+        fail("Assertion error, invalid xml passed to function. Substring should start with \"<\".   Please report.")
+    cursor = label_start
+    label = ""
+    # Grab the basic label and section off attributes (or close the tag)
+    for _ in range(cursor, len(xml)+1): # Invoke an IOB if we exceed the string length.
+        if xml[cursor].isspace():
+            # found label but tag isn't fully processed, so increment and break out of this section.
+            label = xml[label_start:cursor]
+            cursor += 1
+            break;
+        elif xml[cursor] == ">":
+            # We found tag end, so short-circuit.
+            return struct(
+                label = xml[label_start:cursor], end = cursor+1, attrs = struct(start = 0, end = 0))
+        elif xml[cursor:cursor+2] == "/>":
+            # We found tag end for an empty tag, so short-circuit.
+            label = xml[label_start:cursor]
+            cursor += 2
+            return struct(label = label, end = cursor, attrs = struct(start = 0, end = 0))
+        cursor += 1
+
+    # At this point, we are past the label.  Eat up whitespace.
+    for _ in range(cursor, len(xml)+1): # Invoke an IOB if we exceed the string length.
+        if not xml[cursor].isspace():
+            break
+        cursor += 1
+
+    if xml[cursor] == ">":
+        # Found an end after the label, before any attributes.
+        return struct(label = label, end = cursor+1, attrs = struct(start = 0, end = 0))
+    if xml[cursor:cursor+2] == "/>" :
+        # Found an end after the label, before any attributes.
+        return struct(label = label, end = cursor+2, attrs = struct(start = 0, end = 0))
+
+    #Found an attribute section, so grab it.
+    attr_start = cursor
+    in_quotes = False
+    for _ in range(cursor, len(xml)+1): # Invoke an IOB if we exceed the string length.
+        if xml[cursor] == "\"":
+            in_quotes = not in_quotes
+        elif not in_quotes:
+            if xml[cursor] == ">":
+                return _process_element_tail(xml, label, cursor, attr_start, tag_end = cursor + 1)
+            elif xml[cursor:cursor + 2] == "/>":
+                return _process_element_tail(xml, label, cursor, attr_start, tag_end = cursor + 2)
+            elif xml[cursor:cursor + 2] == "?>":
+                return _process_element_tail(xml, label, cursor, attr_start, tag_end = cursor + 2)
+        cursor += 1
+
+    fail("""Badly formed document has a no end to the tag. Please file a bug: "%s" """ % xml)
+
+# Scans forward in the xml, looking for the first non-comment xml element start.
+def _find_element_start(xml, start_from):
+    cursor = xml.find("<", start_from)
+    if cursor == -1:
+        return -1 # no more tags in this text.
+
+    # Scan for comments.
+    for _ in range(cursor, len(xml)):
+        # Need to check for multiple comment sections.
+        if len(xml) - cursor > 4 and xml[cursor:cursor+4] == "<!--":
+            cursor += 4
+            # Found a comment, scan forward to the comment end.
+            for _ in range(cursor, len(xml)):
+                if xml[cursor] == "-" and xml[cursor+1] == "-":
+                    # maybe comment end?
+                    if xml[cursor+2] == ">":
+                        cursor +=3
+                        cursor = xml.find("<", cursor)
+                        if cursor == -1:
+                            return -1 # no more tags in this text.
+                        break # Found comment end, reset start and cursor and break
+                    else:
+                        fail("XML comments may not contain the string \"--\". %s" % xml)
+                else:
+                    cursor += 1
+        else:
+            return cursor
+    return cursor
+
+# Description
+#    Returns the next tag (optionally within a substring), including its label and start/end.
+#    The start/end are relative to the start of the xml string, not the substring start index,
+#    but the search is constrained to the substring.
+#
+#    This implementation skips over xml comment sections, which are NOT represented as a element
+#
+#    Note: this is a bit inefficient, creating two structs, but the code to do it in one was unreadable.
+def _next_element(xml, start_from = 0):
+    start = _find_element_start(xml, start_from)
+    if start == -1:
+        return None # no more tags in this text.
+
+    tag_internals = _find_element_end(xml, start)
+    label = tag_internals.label
+
+    # Process the kind/type of the element (and reset a few sizes, so we can target the internal structure.
+    kind = elements.kind.start
+    if label.startswith("/"):
+        label = label[1:]
+        kind = elements.kind.end
+    elif xml[tag_internals.end-2:tag_internals.end] == "/>": # element tag ends in /> instead of >
+        kind = elements.kind.empty
+    elif label.startswith("?"): # This is a prefix, special element.
+        label = label[1:]
+        kind = elements.kind.xml
+
+    return struct(
+        label = label,
+        start = start,
+        end = tag_internals.end,
+        skipped = start - start_from,
+        kind = kind,
+        attrs = xml[tag_internals.attrs.start:tag_internals.attrs.end],
+    )
+
+# Description:
+#   Returns an array of element_token structs, containing the start/end and label of the element token, as well as
+#   the number of characters from the substring strat.
+#
+#   This tokenizer generally is implemented as an iterative string-scanner, as Starlark has no recursion, and it
+#   isn't clear how much memory would be chewed up by repeated chopping of the string into bits in the internals.
+#   The parser can consume the token array and walk the string, while it builds the tree (which is its API, so at
+#   least there it has to make a bunch of objects).  This may be pre-optimization.  But given that iteration is
+#   the only technical option, avoiding extra string building seemed wise.
+def _element_token_array(xml):
+    tokens = []
+    prev = None
+    index = 0
+    for x in range(0, len(xml)):
+        cursor = prev.end if prev else 0
+        token = elements.next(xml, cursor)
+        if not token:
+            break
+        tokens += [token]
+        prev = token
+    return tokens
+
+# Description:
+#   A simplified maven XML parser, which ignores namespaces, mostly ignores (but preserves the text of) xml attributes.
+#
+#   This parser is limited, in that it:
+#     * does not support mixed content (elements with both non-whitespace text content and child elements)
+#     * does not support xml namespaces
+#     * does not preserve comments in the element tree
+#     * does not keep a dictionary of attributes.
+#     * does not fully validate
+#       - It does some in-process validation but doesn't check, for instance, that there is a single standard root
+#
+#
+#   The parser scans the text stream, tokenizing it, and assembling the resulting tokens into nodes in an element
+#   tree.  Each node is defined as follows:
+#
+#   struct(
+#     label -> The tag name of this element
+#     content -> Text content if it contains any
+#     children[] -> A list of child nodes (if any)
+#   )
+#
+# Returns:
+#   An element tree with an xml_node structure defined above.
+def _parse(xml):
+    path = [] # The current node in the tree, (e.g. ["project", "dependencies", "dependency[0]"]
+    tokens = elements.token_array(xml)
+    root = struct(label = None, content = None, children = [])
+    path += [root]
+    prev = None
+    for i in range(0, len(tokens)):
+        token = tokens[i]
+        if token.kind == elements.kind.xml:
+            node = struct(
+                label = token.label,
+                content = None,
+                children = [])
+            path[-1].children.append(node)
+        elif token.kind == elements.kind.start:
+            next = tokens[i+1]
+            if next.label == token.label and next.kind == elements.kind.end:
+                content = xml[next.start - next.skipped:next.start]
+                # No child elements, so treat the prefix of the next token as CNAME content.
+                node = struct(
+                    label = token.label,
+                    content = content,
+                    children = [])
+            else:
+                # Has child elements, so ignore text content
+                node = struct(
+                    label = token.label,
+                    content = None,
+                    children = [])
+            path[-1].children.append(node)
+            path.append(node)
+        elif token.kind == elements.kind.end:
+            popped = path.pop()
+            if popped.label != token.label:
+                fail("Unbalanced xml tree: closing tag </%s> incorrectly matched with <%s> in xml %s." % (
+                    token.label, popped.label, xml))
+        elif token.kind == elements.kind.empty:
+            node = struct(
+                label = token.label,
+                content = None,
+                children = [])
+            path[-1].children.append(node) # Attach, but don't bother to push/pop.
+        prev = token
+    return root
+
+elements = struct(
+    kind = _element_kind_enum,
+    next = _next_element,
+    token_array = _element_token_array,
+)
+
+xml = struct(
+    parse = _parse,
+)
+
+for_testing = struct(
+    find_element_end = _find_element_end,
+    find_element_start = _find_element_start
+)


### PR DESCRIPTION
This doesn't (yet) process properties, dependencyManagement sections, or parent poms,
but is a prerequisite of those features.

The parser is a generally complete xml parser, with some specific limitations, namely
it doesn't preserve attributes (but does parse them out) since POM files don't use
attributes. It also doesn't support xml namespaces, drops comments, and does not support
mixed content (xml elements with both non-whitespace text and child-elements). There is
no reason it could not support any of these, but these are not necessary for processing
pom.xml files.

It also has no xpath or equivalent querying system, and performs only minimal in-process
validation. It may accept invalid XML documents (though it does reject unbalanced xml
elements).

This commit also hooks up the new infrastructure in place of the old "scraping" approach
and cleans up the older stuff. 

Fixes #23 