### PR TITLE
Support configurable artifact properties.

### DIFF
--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -244,6 +244,8 @@ def _validate_artifacts(artifact_definitions = {}):
             errors += ["""Artifact "%s" missing version""" % spec]
         if not properties.get("sha256", None) and not _fix_string_booleans(properties.get("insecure", False)):
             errors += ["""Artifact "%s" is mising a sha256. Either supply it or mark it "insecure".""" % spec]
+        if properties.get("sha256", None) and _fix_string_booleans(properties.get("insecure", False)):
+            errors += ["""Artifact "%s" cannot be both insecure and have a sha256.  Specify one or the other.""" % spec]
     if bool(errors):
         fail("Errors found:\n    %s" % "\n    ".join(errors))
 
@@ -348,8 +350,8 @@ def maven_repository_specification(
         # by the artifact key itself.
         #
         # The currently supported properties are:
-        #    sha256 -> the hash of the artifact file to be downloaded.
-        #    insecure -> if true, don't fail on a missing sha256 hash.
+        #    sha256 -> the hash of the artifact file to be downloaded. (Incompatible with "insecure")
+        #    insecure -> if true, don't fail on a missing sha256 hash. (Incompatible with "sha256")
         artifacts = {},
 
         # The list of artifacts (without sha256 hashes) that will be used without file hash checking.

--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -227,7 +227,7 @@ def _fix_string_booleans(value):
     return bool(value)
 
 # If artifact/sha pair has missing sha hashes, reject it.
-def _validate_artifacts(artifact_definitions = {}):
+def _validate_artifacts(artifact_definitions):
     errors = []
     if not bool(artifacts):
         errors += ["At least one artifact must be specified."]

--- a/maven/tests/all_tests.bzl
+++ b/maven/tests/all_tests.bzl
@@ -1,5 +1,6 @@
 load(":dicts_test.bzl", dicts = "suite")
 load(":paths_test.bzl", paths = "suite")
+load(":maven_test.bzl", maven = "suite")
 load(":poms_test.bzl", poms = "suite")
 load(":sets_test.bzl", set_tests = "suite")
 load(":strings_test.bzl", strings = "suite")
@@ -8,7 +9,7 @@ load(":xml_test.bzl", xml = "suite")
 load("//maven:sets.bzl", "sets")
 
 
-SUITES = [dicts, paths, poms, set_tests, strings, xml]
+SUITES = [dicts, paths, maven, poms, set_tests, strings, xml]
 
 def _validate(ctx, suites):
     # Function objects don't have good properties, so we hack it from the string representation.

--- a/maven/tests/maven_test.bzl
+++ b/maven/tests/maven_test.bzl
@@ -1,0 +1,15 @@
+load(":testing.bzl", "asserts", "test_suite")
+load("//maven:maven.bzl", "for_testing")
+load("//maven:sets.bzl", "sets")
+
+def unsupported_keys_test(env):
+    asserts.equals(env, sets.new("foo", "bar"), for_testing.unsupported_keys(["foo", "sha256", "insecure", "bar"]))
+
+def handle_legacy_sha_handling(env):
+    asserts.equals(env,
+        expected = {"foo:bar:1.0": { "sha256": "abcdef"}},
+        actual = for_testing.handle_legacy_specifications({"foo:bar:1.0": "abcdef"}, []))
+
+# Roll-up function.
+def suite():
+    return test_suite("maven processing", tests = [unsupported_keys_test, handle_legacy_sha_handling])

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -11,37 +11,34 @@ load(
 
 maven_repository_specification(
     name = "maven",
-    insecure_artifacts = [
-        "com.google.dagger:dagger:2.20",
-        "com.google.dagger:dagger-compiler:2.20",
-        "com.google.dagger:dagger-producers:2.20",
-        "com.google.dagger:dagger-spi:2.20",
-        "com.google.code.findbugs:jsr305:3.0.2",
-        "com.google.errorprone:javac-shaded:9+181-r4173-1",
-        "com.google.googlejavaformat:google-java-format:1.6",
-        "com.squareup:javapoet:1.11.1",
-        "org.checkerframework:checker-compat-qual:2.5.5",
-        "javax.annotation:jsr250-api:1.0",
-        "javax.inject:javax.inject:1",
-        "junit:junit:4.13-beta-1",
-        "com.google.errorprone:error_prone_annotations:2.1.3",
-        "com.google.j2objc:j2objc-annotations:1.1",
-        "org.codehaus.mojo:animal-sniffer-annotations:1.14",
-        "org.hamcrest:hamcrest-core:1.3",
-    ],
     artifacts = {
-        # For illustration, most artifacts should actually be in this form, to ensure that only known .jar contents
-        # are imported into the workspace. (repository injection attacks via DNS poisoning are no fun)
-        "com.google.guava:guava:25.0-jre": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9",
+        # This is the proper way to specify an artifact
+        "com.google.guava:guava:25.0-jre": { "sha256": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9" },
+        "com.google.dagger:dagger:2.20":   { "sha256": "d37a556d8d57e2428c20e222b95346512d11fcf2174d581489a69a1439b886fb" },
+        # This is how you specify an artifact that has no hash.  You must either supply a sha256 hash of the jar file
+        # or specify that the dep is insecure.
+        "com.google.dagger:dagger-compiler:2.20":              { "insecure": True },
+        "com.google.dagger:dagger-producers:2.20":             { "insecure": True },
+        "com.google.dagger:dagger-spi:2.20":                   { "insecure": True },
+        "com.google.code.findbugs:jsr305:3.0.2":               { "insecure": True },
+        "com.google.errorprone:javac-shaded:9+181-r4173-1":    { "insecure": True },
+        "com.google.googlejavaformat:google-java-format:1.6":  { "insecure": True },
+        "com.squareup:javapoet:1.11.1":                        { "insecure": True },
+        "org.checkerframework:checker-compat-qual:2.5.5":      { "insecure": True },
+        "javax.annotation:jsr250-api:1.0":                     { "insecure": True },
+        "javax.inject:javax.inject:1":                         { "insecure": True },
+        "junit:junit:4.13-beta-1":                             { "insecure": True },
+        "com.google.errorprone:error_prone_annotations:2.1.3": { "insecure": True },
+        "com.google.j2objc:j2objc-annotations:1.1":            { "insecure": True },
+        "org.codehaus.mojo:animal-sniffer-annotations:1.14":   { "insecure": True },
+        "org.hamcrest:hamcrest-core:1.3":                      { "insecure": True },
     },
     dependency_target_substitutes = {
         # Because we rewrite dagger -> dagger_api (and make a wrapper target "dagger" that exports the dagger
         # annotation processor) we need to rewrite the internal dependencies inside the com/google/dagger package
         # to reflect this.
         # "groupId": { "full bazel target": "full alternate target" }
-        "com.google.dagger": {
-            "@maven//com/google/dagger:dagger": "@maven//com/google/dagger:dagger_api",
-        },
+        "com.google.dagger": { "@maven//com/google/dagger:dagger": "@maven//com/google/dagger:dagger_api" },
     },
     build_substitutes = {
         "com.google.dagger:dagger": DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN.format(dagger_version = "2.20"),


### PR DESCRIPTION
Rework the API for maven_repository_specification to allow each artifact to have a property dictionary attached.  The first two properties supported are sha256 (and this replaces just passing a string as the sha) and insecure, which replaces the insecure_artifacts approach, by making you just add a property to it if you don't include the sha.  This also allows for later expansion of the feature set for per-artifact manipulation.  This could replace build_substitutions also, but that will happen in a later commit.

Also fixes the test rig a bit, to make it so that a missing declaration of a suite will be caught.  Minor validation, but helpful.

Lastly, support the older configuration style, but print deprecation messages, and in the process, rework validation of the input and print decent errors.