### PR TITLE
Make the pom processing return the fully inferred dependency information, from a given 'effective' pom.

### DIFF
--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -128,7 +128,7 @@ def _get_effective_pom(inheritance_chain):
         merged = poms.merge_parent(parent = merged, child = next)
     return merged
 
-def _get_dependencies_from_pom_files(ctx, artifact, group_path):
+def _get_dependencies_from_pom_files(ctx, artifact):
     inheritance_chain = _get_inheritance_chain(ctx, _fetch_pom(ctx, artifact))
     project = _get_effective_pom(inheritance_chain)
     maven_deps = poms.extract_dependencies(project)
@@ -174,7 +174,7 @@ def _generate_maven_repository_impl(ctx):
             artifact = artifacts.annotate(artifacts.parse_spec(spec))
             coordinates = "%s:%s" % (artifact.group_id, artifact.artifact_id)
             sets.add(processed_artifacts, coordinates)
-            maven_deps = _get_dependencies_from_pom_files(ctx, artifact, group_path)
+            maven_deps = _get_dependencies_from_pom_files(ctx, artifact)
             maven_deps = [x for x in maven_deps if _should_include_dependency(x)]
             found_artifacts = {}
             bazel_deps = []

--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -30,10 +30,10 @@ labels = struct(
 def _process_dependency(dep_node):
     group_id = None
     artifact_id = None
-    version = "INFERRED"
-    type = "jar"
+    version = None
+    type = None
     optional = False
-    scope = "compile"
+    scope = None
     classifier = None
     system_path = None
 
@@ -43,8 +43,7 @@ def _process_dependency(dep_node):
         elif c.label == labels.ARTIFACT_ID:
             artifact_id = c.content
         elif c.label == labels.VERSION:
-            # TODO(cgruber) handle property substitution.
-            version = "INFERRED" if strings.contains(c.content, "$") else c.content
+            version = c.content
         elif c.label == labels.CLASSIFIER:
             classifier = c.content
         elif c.label == labels.TYPE:
@@ -56,6 +55,26 @@ def _process_dependency(dep_node):
         elif c.label == labels.SYSTEM_PATH:
             system_path = c.content
 
+    return _dependency(
+        group_id = group_id,
+        artifact_id = artifact_id,
+        version = version,
+        type = type,
+        optional = optional,
+        scope = scope,
+        classifier = classifier,
+        system_path = system_path,
+    )
+
+def _dependency(
+        group_id,
+        artifact_id,
+        version = None,
+        type = None,
+        optional = None,
+        scope = None,
+        classifier = None,
+        system_path = None):
     return struct(
         group_id = group_id,
         artifact_id = artifact_id,
@@ -68,6 +87,17 @@ def _process_dependency(dep_node):
         coordinate = "%s:%s" % (group_id, artifact_id),
     )
 
+# A set of property defaults for dependencies, to be merged at the last minute.  Omits the groupId
+# and artifactId so it will blow up if used anywhere but in the final merge step.
+_DEPENDENCY_DEFAULT = struct(
+    version = None,
+    type = "jar",
+    optional = False,
+    scope = "compile",
+    classifier = None,
+    system_path = None,
+)
+
 # Extracts dependency coordinates from a given <dependencies> node of a pom node.
 # The parameter should be an xml node containing the tag <dependencies>
 def _extract_dependencies(parent_node):
@@ -78,7 +108,68 @@ def _extract_dependencies(parent_node):
 # The parameter should be an xml node containing the tag <dependencyManagement>
 def _extract_dependency_management(project_node):
     node = xml.find_first(project_node, labels.DEPENDENCY_MANAGEMENT)
-    return poms.extract_dependencies(node) if bool(node) else []
+    return _extract_dependencies(node) if bool(node) else []
+
+def _merge_dependency(fallback, dependency):
+    if not bool(fallback):
+        return dependency
+
+    # If this were a node tree, we could re-use the leaf element merging, but it's a struct. :(
+    # groupid and artifactid are always present, so don't bother merging them.
+    return _dependency(
+        group_id = dependency.group_id,
+        artifact_id = dependency.artifact_id,
+        version = dependency.version if bool(dependency.version) else fallback.version,
+        type = dependency.type if bool(dependency.type) else fallback.type,
+        optional = dependency.optional if bool(dependency.optional) else fallback.optional,
+        scope = dependency.scope if bool(dependency.scope) else fallback.scope,
+        classifier = dependency.classifier if bool(dependency.classifier) else fallback.classifier,
+        system_path = dependency.system_path if bool(dependency.system_path) else fallback.system_path,
+    )
+
+def _get_variable(string):
+    start = string.find("${")
+    end = string.find("}")
+    return string[start + 2:end] if start >= 0 and end >= 0 and start < end - 3 else None
+
+def _substitute_variable_if_present(string, properties):
+    if not bool(string):
+        return None
+    variable_label = _get_variable(string)
+    if bool(variable_label):
+        substitution = properties.get(variable_label, None)
+        if bool(substitution):
+            string = string.replace("${%s}" % variable_label, substitution)
+    return string
+
+def _apply_property(dependency, properties):
+    # For now just check <version> and <groupId>
+    return _dependency(
+        group_id = _substitute_variable_if_present(dependency.group_id, properties),
+        artifact_id = dependency.artifact_id,
+        version = _substitute_variable_if_present(dependency.version, properties),
+        type = dependency.type,
+        optional = dependency.optional,
+        scope = dependency.scope,
+        classifier = dependency.classifier,
+        system_path = dependency.system_path,
+    )
+
+# Merges any information from <dependencyManagement> and <properties> sections and returns the
+# resulting processed dependencies.
+def _get_processed_dependencies(project_node):
+    result = []
+    dependency_management = {}
+    for dep in _extract_dependency_management(project_node):
+        dependency_management[dep.coordinate] = dep
+    dependencies = _extract_dependencies(project_node)
+    properties = _extract_properties(project_node)
+    for dep in dependencies:
+        dep = _merge_dependency(dependency_management.get(dep.coordinate, None), dep)
+        dep = _apply_property(dep, properties)
+        dep = _merge_dependency(_DEPENDENCY_DEFAULT, dep)  # fill in any needed default values.
+        result.append(dep)
+    return result
 
 def _process_parent(dep_node):
     group_id = None
@@ -116,6 +207,10 @@ def _extract_properties(project):
     properties = {}
     for node in properties_nodes:
         properties[node.label] = node.content
+    for label in [labels.GROUP_ID, labels.ARTIFACT_ID, labels.VERSION]:
+        node = xml.find_first(project, label)
+        if bool(node):
+            properties["project.%s" % label] = node.content
     return properties
 
 def _format_dependency(dep):
@@ -176,6 +271,11 @@ def _merge_properties_section(parent_node, child_node):
         _children_if_exists(xml.find_first(child_node, labels.PROPERTIES)),
     )
     return xml.new_node(label = labels.PROPERTIES, children = children)
+
+for_testing = struct(
+    get_variable = _get_variable,
+    substitute_variable = _substitute_variable_if_present,
+)
 
 # Description:
 #   Merges the dependency section of the pom.  This makes an assumption that deps sections won't have both the main
@@ -267,7 +367,7 @@ poms = struct(
     parse = _parse,
 
     # Returns a list of structs containing the properties each dependency declared pom xml tree.
-    extract_dependencies = _extract_dependencies,
+    extract_dependencies = _get_processed_dependencies,
 
     # Returns a list of structs each dependency declared in the dependencyManagement of the pom xml tree.
     extract_dependency_management = _extract_dependency_management,

--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -207,6 +207,8 @@ def _extract_properties(project):
     properties = {}
     for node in properties_nodes:
         properties[node.label] = node.content
+
+    # Generate maven's implicit properties from the project itself.
     for label in [labels.GROUP_ID, labels.ARTIFACT_ID, labels.VERSION]:
         node = xml.find_first(project, label)
         if bool(node):

--- a/maven/tests/poms_for_testing.bzl
+++ b/maven/tests/poms_for_testing.bzl
@@ -43,6 +43,7 @@ SYSTEM_PATH_POM = POM_PREFIX + """
 """ + POM_SUFFIX
 
 SIMPLE_PROPERTIES_POM = POM_PREFIX + """
+  <version>2.0</version>
   <properties>
     <foo>foo</foo>
     <foo.bar>bar</foo.bar>

--- a/maven/tests/poms_merging_test.bzl
+++ b/maven/tests/poms_merging_test.bzl
@@ -58,10 +58,13 @@ def merge_simpler_grandparent_parent_test(env):
     asserts.equals(env, "pom", xml.find_first(merged, "packaging").content, "merged packaging")
 
     properties = poms.extract_properties(merged)
-    asserts.equals(env, 3, len(properties), "number of properties")
+    asserts.equals(env, 6, len(properties), "number of properties")
     asserts.equals(env, "bar", properties["foo"], "merged value of 'foo'")
     asserts.equals(env, "1.0", properties["findbugs.jsr305"], "merged value of 'findbugs.jsr305'")
     asserts.equals(env, "blah", properties["baz"], "merged value of 'baz'")
+    asserts.equals(env, "test.group", properties["project.groupId"], "merged value of 'project.groupId'")
+    asserts.equals(env, "parent", properties["project.artifactId"], "merged value of 'project.artifactId'")
+    asserts.equals(env, "1.0", properties["project.version"], "merged value of 'project.version'")
 
     dependencies = poms.extract_dependencies(merged)
     asserts.equals(env, 1, len(dependencies), "number of dependencies")
@@ -85,17 +88,20 @@ def merge_full_chain_test(env):
     asserts.equals(env, "jar", xml.find_first(merged, "packaging").content, "merged packaging")
 
     properties = poms.extract_properties(merged)
-    asserts.equals(env, 4, len(properties), "number of properties")
+    asserts.equals(env, 7, len(properties), "number of properties")
     asserts.equals(env, "bar", properties["foo"], "merged value of 'foo'")
     asserts.equals(env, "1.0", properties["findbugs.jsr305"], "merged value of 'findbugs.jsr305'")
     asserts.equals(env, "blah", properties["baz"], "merged value of 'baz'")
     asserts.equals(env, "5.0", properties["animal.sniffer.version"], "merged value of 'animal.sniffer.version'")
+    asserts.equals(env, "test.group", properties["project.groupId"], "merged value of 'project.groupId'")
+    asserts.equals(env, "child", properties["project.artifactId"], "merged value of 'project.artifactId'")
+    asserts.equals(env, "1.0", properties["project.version"], "merged value of 'project.version'")
 
     dependencies = poms.extract_dependencies(merged)
     asserts.equals(env, 5, len(dependencies), "number of dependencies")
+    # Values from extract_dependencies may include inferred values - that's separately tested.
 
     deps_mgt = poms.extract_dependency_management(merged)
-    print(deps_mgt)
     asserts.equals(env, 1, len(deps_mgt), "number of dependency management")
     asserts.equals(env, "test", deps_mgt[0].scope)
 
@@ -104,11 +110,28 @@ def merge_full_chain_test(env):
     # The core functionality should be asserted about more precisely in the above assertions.
     asserts.equals(env, expected.to_json(), merged.to_json(), "merged pom node tree")
 
+def inferred_values_in_dependencies_test(env):
+    dependencies = poms.extract_dependencies(poms.parse(MERGED_EXPECTED_POM))
+    indexed_dependencies = {}
+    for dep in dependencies:
+        indexed_dependencies[dep.coordinate] = dep
+    asserts.equals(env, 5, len(dependencies), "number of dependencies")
+    asserts.true(env, indexed_dependencies.get("com.google.code.findbugs:jsr305", None), "has jsr305")
+    asserts.equals(
+        env = env,
+        expected = "1.0",
+        actual = indexed_dependencies.get("com.google.code.findbugs:jsr305", None).version,
+        message = "jsr305 sould have version 1.0 substituted for ${findbugs.jsr305}",
+    )
+    asserts.true(env, indexed_dependencies.get("junit:junit", None), "has junit:junit")
+    asserts.equals(env, "test", indexed_dependencies.get("junit:junit", None).scope, "junit is test scoped")
+
 TESTS = [
     merge_properties_test,
     merge_dependency_test,
     merge_simpler_grandparent_parent_test,
     merge_full_chain_test,
+    inferred_values_in_dependencies_test,
 ]
 
 # Roll-up function.

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -1,48 +1,46 @@
 workspace(name = "test_workspace")
 
 # Set up maven
-local_repository(name = "maven_repository_rules", path = "../..")
-load("@maven_repository_rules//maven:maven.bzl", "maven_repository_specification")
-load(
-    ":build_substitution_templates.bzl",
-    "DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN",
-    "GOOGLE_JAVA_FORMAT_BUILD_SUBSTITUTE",
+local_repository(
+    name = "maven_repository_rules",
+    path = "../..",
 )
+
+load("@maven_repository_rules//maven:maven.bzl", "maven_repository_specification")
+load(":build_substitution_templates.bzl", "DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN")
 
 maven_repository_specification(
     name = "maven",
     artifacts = {
         # This is the proper way to specify an artifact
-        "com.google.guava:guava:25.0-jre": { "sha256": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9" },
-        "com.google.dagger:dagger:2.20":   { "sha256": "d37a556d8d57e2428c20e222b95346512d11fcf2174d581489a69a1439b886fb" },
+        "com.google.guava:guava:25.0-jre": {"sha256": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9"},
+        "com.google.dagger:dagger:2.20": {"sha256": "d37a556d8d57e2428c20e222b95346512d11fcf2174d581489a69a1439b886fb"},
         # This is how you specify an artifact that has no hash.  You must either supply a sha256 hash of the jar file
         # or specify that the dep is insecure.
-        "com.google.dagger:dagger-compiler:2.20":              { "insecure": True },
-        "com.google.dagger:dagger-producers:2.20":             { "insecure": True },
-        "com.google.dagger:dagger-spi:2.20":                   { "insecure": True },
-        "com.google.code.findbugs:jsr305:3.0.2":               { "insecure": True },
-        "com.google.errorprone:javac-shaded:9+181-r4173-1":    { "insecure": True },
-        "com.google.googlejavaformat:google-java-format:1.6":  { "insecure": True },
-        "com.squareup:javapoet:1.11.1":                        { "insecure": True },
-        "org.checkerframework:checker-compat-qual:2.5.5":      { "insecure": True },
-        "javax.annotation:jsr250-api:1.0":                     { "insecure": True },
-        "javax.inject:javax.inject:1":                         { "insecure": True },
-        "junit:junit:4.13-beta-1":                             { "insecure": True },
-        "com.google.errorprone:error_prone_annotations:2.1.3": { "insecure": True },
-        "com.google.j2objc:j2objc-annotations:1.1":            { "insecure": True },
-        "org.codehaus.mojo:animal-sniffer-annotations:1.14":   { "insecure": True },
-        "org.hamcrest:hamcrest-core:1.3":                      { "insecure": True },
+        "com.google.dagger:dagger-compiler:2.20": {"insecure": True},
+        "com.google.dagger:dagger-producers:2.20": {"insecure": True},
+        "com.google.dagger:dagger-spi:2.20": {"insecure": True},
+        "com.google.code.findbugs:jsr305:3.0.2": {"insecure": True},
+        "com.google.errorprone:javac-shaded:9+181-r4173-1": {"insecure": True},
+        "com.google.googlejavaformat:google-java-format:1.6": {"insecure": True},
+        "com.squareup:javapoet:1.11.1": {"insecure": True},
+        "org.checkerframework:checker-compat-qual:2.5.5": {"insecure": True},
+        "javax.annotation:jsr250-api:1.0": {"insecure": True},
+        "javax.inject:javax.inject:1": {"insecure": True},
+        "junit:junit:4.13-beta-1": {"insecure": True},
+        "com.google.errorprone:error_prone_annotations:2.1.3": {"insecure": True},
+        "com.google.j2objc:j2objc-annotations:1.1": {"insecure": True},
+        "org.codehaus.mojo:animal-sniffer-annotations:1.14": {"insecure": True},
+        "org.hamcrest:hamcrest-core:1.3": {"insecure": True},
+    },
+    build_substitutes = {
+        "com.google.dagger:dagger": DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN.format(dagger_version = "2.20"),
     },
     dependency_target_substitutes = {
         # Because we rewrite dagger -> dagger_api (and make a wrapper target "dagger" that exports the dagger
         # annotation processor) we need to rewrite the internal dependencies inside the com/google/dagger package
         # to reflect this.
         # "groupId": { "full bazel target": "full alternate target" }
-        "com.google.dagger": { "@maven//com/google/dagger:dagger": "@maven//com/google/dagger:dagger_api" },
+        "com.google.dagger": {"@maven//com/google/dagger:dagger": "@maven//com/google/dagger:dagger_api"},
     },
-    build_substitutes = {
-        "com.google.dagger:dagger": DAGGER_BUILD_SUBSTITUTE_WITH_PLUGIN.format(dagger_version = "2.20"),
-        "com.google.googlejavaformat:google-java-format": GOOGLE_JAVA_FORMAT_BUILD_SUBSTITUTE,
-    }
 )
-

--- a/test/test_workspace/build_substitution_templates.bzl
+++ b/test/test_workspace/build_substitution_templates.bzl
@@ -8,7 +8,6 @@
 #   needs curation.  Indeed, it mostly only has variable substitution because the unversioned coordinates don't change
 #   so frequently.
 
-
 # Description:
 #   Substitutes the naive maven_jvm_artifact for com.google.dagger:dagger with a flagor that exports the compiler
 #   plugin.  Contains the `dagger_version` substitution variable.
@@ -43,21 +42,5 @@ java_plugin(
    processor_class = "dagger.internal.codegen.ComponentProcessor",
    generates_api = True,
    deps = [":dagger_compiler"],
-)
-"""
-
-# Description:
-#   Substitute this since the naive reading of the .pom doesn't properly list some dependencies as test-only.
-#   This shouldn't be necessary once property-substitution and parent-pom integration are supported.
-GOOGLE_JAVA_FORMAT_BUILD_SUBSTITUTE = """
-maven_jvm_artifact(
-    name = "google_java_format",
-    artifact = "com.google.googlejavaformat:google-java-format:1.6",
-    deps = [
-        "@maven//com/google/guava",
-        "@maven//com/google/errorprone:javac_shaded",
-        "@maven//com/google/code/findbugs:jsr305",
-        "@maven//com/google/errorprone:error_prone_annotations",
-    ],
 )
 """


### PR DESCRIPTION
As of this commit, the dependencies of a pom can be obtained, incorporating any inherited metadata, any `dependencyManagement` sections, and substituting any properties.  The resulting deps should then be accurate (insofar as the pom.xml files themselves are accurate).  The system can then safely use these deps values to generate a deps list in the bazel workspace representing the maven repository with no corrective substitutions necessary to handle correctly specified pom data. 

Fixes #14 and fixes #15 