### PR TITLE
Make the parser parse CNAME elements in xml files

### DIFF
--- a/maven/tests/xml_test.bzl
+++ b/maven/tests/xml_test.bzl
@@ -85,7 +85,9 @@ XML_DOC = """
   <bar>4.0.0</bar>
   <qof foo="blah>foo" />
   <blah a="b">
-    <baz q="r" />
+    <baz q="r" /> <![CDATA[Some text before a link, which is here:
+                      <a href="http://squareup.com">Square, Inc.</a>
+                  ]]>
   </blah a="b">      </foo>
 """
 

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -35,8 +35,9 @@ maven_repository_specification(
         "com.google.j2objc:j2objc-annotations:1.1": {"insecure": True},
         "org.codehaus.mojo:animal-sniffer-annotations:1.14": {"insecure": True},
         "org.hamcrest:hamcrest-core:1.3": {"insecure": True},
-        "com.android.tools.build:builder-model:2.3.0": { "insecure": True },
+        "com.android.tools.build:builder-model:2.3.0": { "insecure": True }, # tests regression #38
         "com.android.tools:annotations:25.3.0": { "insecure": True },
+        "javax.annotation:javax.annotation-api:1.2": { "insecure": True }, # tests regression #40
     },
     # Because these apply to all targets within a group, it's specified separately from the artifact list.
     dependency_target_substitutes = {


### PR DESCRIPTION
Since some pom.xml files apparently do so, handle `<![CNAME[ ... ]]>`

Also tidy the comment processing, of which this is a peer, so it's a bit more compact. 

Fixes #40