### PR TITLE
Add a case to the test_workspace which proves that the compile-time transitive deps are present.

### DIFF
--- a/maven/jvm.bzl
+++ b/maven/jvm.bzl
@@ -38,17 +38,16 @@ def _raw_jvm_import(ctx):
     Supplied jar parameter (%s) transitively included more than one binary jar and one (optional)
     source jar.  Found: %s, %s""" % (ctx.file.jar, jars, source_jars))
 
-    return [
-        DefaultInfo(files = depset(jars)),
-        JavaInfo(
-            output_jar = jars[0],
-            compile_jar = jars[0],
-            source_jar = source_jars[0] if bool(source_jars) else None,
-            deps = [dep[JavaInfo] for dep in ctx.attr.deps if JavaInfo in dep],
-            runtime_deps = [dep[JavaInfo] for dep in ctx.attr.runtime_deps if JavaInfo in dep],
-            neverlink = getattr(ctx.attr, "neverlink", False),
-        ),
-    ]
+    default_info = DefaultInfo(files = depset(jars))
+    java_info = JavaInfo(
+        output_jar = jars[0],
+        compile_jar = jars[0],
+        source_jar = source_jars[0] if bool(source_jars) else None,
+        deps = [dep[JavaInfo] for dep in ctx.attr.deps if JavaInfo in dep],
+        runtime_deps = [dep[JavaInfo] for dep in ctx.attr.runtime_deps if JavaInfo in dep],
+        neverlink = getattr(ctx.attr, "neverlink", False),
+    )
+    return [default_info, java_info]
 
 raw_jvm_import = rule(
     attrs = {

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -34,7 +34,9 @@ kt_register_toolchains()
 maven_repository_specification(
     name = "maven",
     artifacts = {
-        # This is the proper way to specify an artifact
+        # This is the proper way to specify an artifact.  It contains the artifact, plus a configuration dictionary.
+        # The config dictionary contains a sha256 hash. This both ensures the file downloaded is the expected one, but
+        # also caches the file in bazel's "content addressable" cache, which survives build clean. 
         "com.google.guava:guava:25.0-jre": {"sha256": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9"},
         "com.google.dagger:dagger:2.20": {
             "sha256": "d37a556d8d57e2428c20e222b95346512d11fcf2174d581489a69a1439b886fb",
@@ -50,6 +52,8 @@ maven_repository_specification(
         "com.google.googlejavaformat:google-java-format:1.6": {"insecure": True},
         "com.google.truth:truth:0.42": {"insecure": True},
         "com.squareup:javapoet:1.11.1": {"insecure": True},
+        "io.reactivex.rxjava2:rxjava:2.2.6": {"insecure": True},
+        "org.reactivestreams:reactive-streams:1.0.2": {"insecure": True},
         "org.checkerframework:checker-compat-qual:2.5.5": {"insecure": True},
         "javax.annotation:jsr250-api:1.0": {"insecure": True},
         "javax.inject:javax.inject:1": {"insecure": True},
@@ -69,10 +73,7 @@ maven_repository_specification(
         "org.checkerframework:checker-qual:2.5.3": {"insecure": True},
         "com.googlecode.java-diff-utils:diffutils:1.3.0": {"insecure": True},
         "com.google.auto.value:auto-value-annotations:1.6.3": {"insecure": True},
-        "com.google.auto.value:auto-value:1.6.3": {
-            "insecure": True,
-            "build_snippet": AUTO_VALUE_BUILD_SNIPPET_WITH_PLUGIN.format(version = "1.6.3"),
-        },
+        "com.google.auto.value:auto-value:1.6.3": { "insecure": True, "build_snippet": AUTO_VALUE_BUILD_SNIPPET_WITH_PLUGIN.format(version = "1.6.3"), },
     },
     # Because these apply to all targets within a group, it's specified separately from the artifact list.
     dependency_target_substitutes = {

--- a/test/test_workspace/java/foo/BUILD.bazel
+++ b/test/test_workspace/java/foo/BUILD.bazel
@@ -9,9 +9,18 @@ kt_jvm_library(
         "Foo.java",
     ],
     deps = [
+        ":blah",
         "@maven//com/google/auto/value",
         "@maven//com/google/dagger",
         "@maven//com/google/guava",
         "@maven//javax/inject:javax_inject",
+    ],
+)
+
+java_library(
+    name = "blah",
+    srcs = ["Blah.java"],
+    deps = [
+        "@maven//io/reactivex/rxjava2:rxjava",
     ],
 )

--- a/test/test_workspace/java/foo/Blah.java
+++ b/test/test_workspace/java/foo/Blah.java
@@ -1,0 +1,8 @@
+package foo;
+
+public class Blah {
+    public void blah() {
+        io.reactivex.Flowable<String> flow = io.reactivex.Flowable.just("blah");
+        flow.blockingFirst().split("a");
+    }
+}

--- a/test/test_workspace/java/foo/Foo.java
+++ b/test/test_workspace/java/foo/Foo.java
@@ -24,6 +24,8 @@ public class Foo {
     Bar bar();
 
     static FooComponent create() {
+      new Blah().blah();
+      // io.reactivex.Flowable.just("blah"); This would fail in kotlinc because of bazelbuild/rules_kotlin#132
       return DaggerFoo_FooComponent.builder().build();
     }
   }


### PR DESCRIPTION
If B deps on A as a part of API, e.g. inheriting from a class, A must be in the compilation classpath.  This case adds a java_library example and a kt_jvm_library example of just such a case (rxjava2's Flowable and reactive-streaming's Publisher).  This succeeds in the java_library case, so it's clear bazel_maven_repository's construction of a JavaInfo is sound. It fails in kotlin (even java compiled by the kotlin rules' kotlinc invocation) because it has half-baked strict-deps support, and ends up not consuming the proper classpath. Because it fails, it's commented out with a note pointing at the issue bazelbuild/rules_kotlin#132.  This can be commented out at hte point where it's fixed.

This tests for the regression noticed in #54 but doesn't fix it since it's not a bug in this project. 