### PR TITLE
Add support for exports= to raw_jvm_imports

### DIFF
--- a/maven/jvm.bzl
+++ b/maven/jvm.bzl
@@ -44,6 +44,7 @@ def _raw_jvm_import(ctx):
         compile_jar = jars[0],
         source_jar = source_jars[0] if bool(source_jars) else None,
         deps = [dep[JavaInfo] for dep in ctx.attr.deps if JavaInfo in dep],
+        exports = [dep[JavaInfo] for dep in ctx.attr.exports if JavaInfo in dep],
         runtime_deps = [dep[JavaInfo] for dep in ctx.attr.runtime_deps if JavaInfo in dep],
         neverlink = getattr(ctx.attr, "neverlink", False),
     )
@@ -58,12 +59,14 @@ raw_jvm_import = rule(
         ),
         "deps": attr.label_list(
             default = [],
-            mandatory = False,
+            providers = [JavaInfo],
+        ),
+        "exports": attr.label_list(
+            default = [],
             providers = [JavaInfo],
         ),
         "runtime_deps": attr.label_list(
             default = [],
-            mandatory = False,
             providers = [JavaInfo],
         ),
         "neverlink": attr.bool(default = False),

--- a/test/test_workspace/build_substitution_templates.bzl
+++ b/test/test_workspace/build_substitution_templates.bzl
@@ -21,6 +21,9 @@ java_library(
 
 maven_jvm_artifact(
    name = "dagger_api",
+   exports = [
+       "@maven//javax/inject:javax_inject",
+   ],
    artifact = "com.google.dagger:dagger:{version}",
 )
 

--- a/test/test_workspace/java/foo/BUILD.bazel
+++ b/test/test_workspace/java/foo/BUILD.bazel
@@ -13,7 +13,6 @@ kt_jvm_library(
         "@maven//com/google/auto/value",
         "@maven//com/google/dagger",
         "@maven//com/google/guava",
-        "@maven//javax/inject:javax_inject",
     ],
 )
 


### PR DESCRIPTION
This is necessary in some cases for workarounds (such as bazelbuild/rules_kotlin#132, or generally supporting convenience exports, such as dagger exporting jsr330, etc.) 