### PR TITLE
Fix boolean coercion of a string

### DIFF
--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -51,7 +51,7 @@ def _process_dependency(dep_node):
         elif c.label == labels.SCOPE:
             scope = c.content
         elif c.label == labels.OPTIONAL:
-            optional = bool(c.content)
+            optional = strings.trim(c.content).lower() == "true"
         elif c.label == labels.SYSTEM_PATH:
             system_path = c.content
 
@@ -368,7 +368,7 @@ poms = struct(
     # Returns an xml element tree of the supplied pom text.
     parse = _parse,
 
-    # Returns a list of structs containing the properties each dependency declared pom xml tree.
+    # Returns a list of structs containing each dependency declared pom xml tree.
     extract_dependencies = _get_processed_dependencies,
 
     # Returns a list of structs each dependency declared in the dependencyManagement of the pom xml tree.

--- a/maven/tests/poms_test.bzl
+++ b/maven/tests/poms_test.bzl
@@ -106,6 +106,27 @@ def substitute_variable_test(env):
     # Not in properties
     asserts.equals(env, "${bar}", for_testing.substitute_variable("${bar}", properties))
 
+
+# Tests issue highlighted in #62 where whitespace and other oddities makes boolean flags parse incorrectly.
+def boolean_options_whitespace_test(env):
+    OPTIONAL_BOOL_POM = """
+        <project><dependencies>
+            <dependency>
+                <groupId>foo</groupId><artifactId>foo</artifactId><version>1.0</version>
+                <optional>false
+                </optional> <!-- Add some whitespace per #62 -->
+            </dependency>
+            <dependency>
+                <groupId>bar</groupId><artifactId>bar</artifactId><version>1.0</version>
+                <optional>true
+                </optional> <!-- Add some whitespace per #62 -->
+            </dependency>
+        </dependencies></project>
+    """
+    dependencies = poms.extract_dependencies(poms.parse(OPTIONAL_BOOL_POM))
+    asserts.false(env, dependencies[0].optional, "optional should be false for foo")
+    asserts.true(env, dependencies[1].optional, "optional should be true for bar")
+
 TESTS = [
     simple_pom_fragment_process,
     simple_pom_fragment_process_scope,
@@ -116,6 +137,7 @@ TESTS = [
     extract_properties_complex_pom_test,
     get_variable_test,
     substitute_variable_test,
+    boolean_options_whitespace_test,
 ]
 
 # Roll-up function.

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -74,6 +74,8 @@ maven_repository_specification(
         "com.googlecode.java-diff-utils:diffutils:1.3.0": {"insecure": True},
         "com.google.auto.value:auto-value-annotations:1.6.3": {"insecure": True},
         "com.google.auto.value:auto-value:1.6.3": { "insecure": True, "build_snippet": AUTO_VALUE_BUILD_SNIPPET_WITH_PLUGIN.format(version = "1.6.3"), },
+        "org.reflections:reflections:0.9.11": { "insecure": True }, # test leniency related to #62.
+        "org.javassist:javassist:3.21.0-GA": { "insecure": True}, # Only needed if #62 is fixed.
     },
     # Because these apply to all targets within a group, it's specified separately from the artifact list.
     dependency_target_substitutes = {


### PR DESCRIPTION
Turns out bool(some_string) does odd things, including returning true on non-empty strings.  Should not have been using magic coercion, but instead needed to test that the content of the string was what Maven interpreted as 'true' and in all other cases return false.

So do that now. Also add a test, and add an example of that with an explanation in the test_workspace.  (can't really test the failure because we can't fail the build-under-test).

Fixes #62 