### PR TITLE
Use the newer respository_ctx.read() API instead of shelling out to 'cat' which doesn't exist on all platforms.

### DIFF
--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -111,10 +111,7 @@ def _fetch_pom(ctx, artifact):
     pom_urls = ["%s/%s" % (repo, artifact.pom) for repo in ctx.attr.repository_urls]
     pom_file = "%s/%s-%s.pom" % (artifact.group_path, artifact.artifact_id, artifact.version)
     ctx.download(url = pom_urls, output = pom_file)
-    result = ctx.execute(["cat", pom_file])
-    if result.return_code:
-        fail("Error reading pom file %s (return code %s)" % (pom_file, result.return_code))
-    return result.stdout
+    return ctx.read(pom_file)
 
 # In theory, this logic should live in poms.bzl, but bazel makes it harder to use the strategy pattern (to pass in a
 # downloader) and we want to keep file and network code out of the poms processing code.

--- a/maven/tests/maven_test.bzl
+++ b/maven/tests/maven_test.bzl
@@ -27,12 +27,8 @@ def handle_legacy_build_snippet_handling(env):
             {"foo:bar:1.0": {"sha256": "abcdef"}}, [], {"foo:bar": "blah"}))
 
 # Set up fakes.
-def _fake_cat_for_get_pom_test(args):
-    return struct(
-        return_code = 0,
-        stdout = COMPLEX_POM,
-        stderr = None,
-    )
+def _fake_read_for_get_pom_test(path):
+    return COMPLEX_POM
 
 def _fake_download(url, output):
     pass
@@ -43,7 +39,7 @@ def _fake_download(url, output):
 def get_pom_test(env):
     fake_ctx = struct(
         download = _fake_download,
-        execute = _fake_cat_for_get_pom_test,
+        read = _fake_read_for_get_pom_test,
         attr = struct(repository_urls = [_FAKE_URL_PREFIX])
     )
     project = poms.parse(
@@ -52,16 +48,12 @@ def get_pom_test(env):
 
 
 # Set up fakes.
-def _fake_cat_for_get_parent_chain(args):
+def _fake_read_for_get_parent_chain(path):
     download_map = {
         "test/group/parent-1.0.pom": PARENT_POM,
         "test/grandparent-1.0.pom": GRANDPARENT_POM,
     }
-    return struct(
-        return_code = 0 if bool(download_map.get(args[1], None)) else 1,
-        stdout = download_map.get(args[1], ""),
-        stderr = None,
-    )
+    return download_map.get(path, "")
 
 def _extract_artifact_id(node):
     for child_node in node.children:
@@ -71,7 +63,7 @@ def _extract_artifact_id(node):
 def get_parent_chain_test(env):
     fake_ctx = struct(
         download = _fake_download,
-        execute = _fake_cat_for_get_parent_chain,
+        read = _fake_read_for_get_parent_chain,
         attr = struct(repository_urls = [_FAKE_URL_PREFIX])
     )
     chain = for_testing.get_inheritance_chain(fake_ctx, COMPLEX_POM)


### PR DESCRIPTION
Fixes #64