### PR TITLE
Cache pom files for configured artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ accessible by offering a cache folder to the rule like so:
 ```
 maven_repository_specification(
     name = "maven",
-    insecure_pom_cache = ".cache/bazel_maven_repository/pom_hashes",
+    cache_poms_insecurely = True,
+    insecure_sha_cache = ".cache/bazel_maven_repository/hashes", # can be omitted - this is the default
     artifacts = {
         "com.google.guava:guava:25.0-jre": { "sha256": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9"},
     }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Release: `1.0`
     - [Mangling](#mangling)
   - [Artifact Configuration](#artifact-configuration)
     - [Sha verification](#sha-verification)
+    - [Pom file sha verification](#pom-file-sha-verification)
     - [Substitution of build targets](#substitution-of-build-targets)
     - [Packaging](#packaging)
     - [Classifiers](#classifiers)
@@ -29,7 +30,7 @@ Release: `1.0`
     - [maven_jvm_artifact](#maven_jvm_artifact)
   - [Limitations](#limitations)
   - [Other Usage Notes](#other-usage-notes)
-    - [Caches](#caches)
+    - [Build state invalidation](#build-state-invalidation)
     - [Clogged WORKSPACE files](#clogged-workspace-files)
     - [Kotlin](#kotlin)
       - [ijar (abi-jar) and inline functions](#ijar-abi-jar-and-inline-functions)
@@ -186,6 +187,36 @@ The rules will reject artifacts without SHAs are not marked as "insecure".
 > Note: These rules cannot validate that the checksum is the right one, only that the one supplied
 > in configuration matches the checksum of the file downloaded.  It is the responsibility of the
 > maintainer to use proper security practices and obtain the expected checksum from a trusted source.
+
+### Pom file sha verification
+
+Artifacts can specify SHA256 checksums for their `.pom` files, via `artifacts`, in the form:
+```
+    artifacts = {
+        "com.google.guava:guava:25.0-jre": {
+            "sha256": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9",
+            "pom_sha256": "68c1ac2817572d6a6eb5c36072c37379f912ec75e99f6bc25aaa7ed2eb2b5ff1",
+        },
+    }
+```
+
+While this is the most secure option, it is also possible to omit this. If omitted, however, .pom
+files will be downloaded each time.  To ease development, an insecure cache mode exists for poms,
+accessible by offering a cache folder to the rule like so:
+
+```
+maven_repository_specification(
+    name = "maven",
+    insecure_pom_cache = ".cache/bazel_maven_repository/pom_hashes",
+    artifacts = {
+        "com.google.guava:guava:25.0-jre": { "sha256": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9"},
+    }
+)
+```
+
+This will cause the sha256 hashes for the various poms to be stored insecurely (as in, unverified)
+in the supplied cache directory.  This implies trusting the .pom you downloaded when the cache is
+being populated, and these are not checked in to the repository.
 
 ### Substitution of build targets
 
@@ -380,7 +411,7 @@ maven_jvm_artifact(
 
 ## Other Usage Notes
 
-### Caches
+### Build state invalidation
 
 Because of the nature of bazel repository/workspace operation, updating the list of artifacts may
 invalidate build caches, and force a re-run of workspace operations (and possibly reduce

--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -143,6 +143,7 @@ def _get_pom_sha256(ctx, artifact, urls, file):
         result = ctx.execute([_POM_HASH_CACHE_WRITE_SCRIPT, pom_result.sha256, cached_file])
         if result.return_code != 0:
             fail("Cache write failed with code %s, stderr: %s", (result.return_code, result.stderr))
+        return pom_result.sha256
     else:
         return strings.trim(sha_cache_result.stdout)
 
@@ -158,7 +159,8 @@ def _fetch_pom(ctx, artifact):
     file = "{group_id}/{artifact_id}-{version}.pom".format(
         group_id = artifact.group_path,
         artifact_id = artifact.artifact_id,
-        version = artifact.version)
+        version = artifact.version,
+    )
     ctx.report_progress("Fetching %s" % file)
 
     sha256 = _get_pom_sha256(ctx, artifact, urls, file) if ctx.attr.insecure_pom_cache else None
@@ -210,7 +212,6 @@ def _should_include_dependency(dep):
         not dep.optional
     )
 
-
 def _generate_maven_repository_impl(ctx):
     # Generate the root WORKSPACE file
     repository_root_path = ctx.path(".")
@@ -220,6 +221,7 @@ def _generate_maven_repository_impl(ctx):
         content = _POM_HASH_CACHE_WRITE_SCRIPT_CONTENT,
         executable = True,
     )
+
     # Generate the per-group_id BUILD.bazel files.
     build_snippets = ctx.attr.build_snippets
     target_substitutes = dicts.decode_nested(ctx.attr.dependency_target_substitutes)
@@ -450,6 +452,7 @@ for_testing = struct(
     unsupported_keys = _unsupported_keys,
     handle_legacy_specifications = _handle_legacy_specifications,
     fetch_pom = _fetch_pom,
+    get_pom_sha256 = _get_pom_sha256,
     get_inheritance_chain = _get_inheritance_chain,
     get_effective_pom = _get_effective_pom,
 )

--- a/maven/tests/maven_test.bzl
+++ b/maven/tests/maven_test.bzl
@@ -33,6 +33,9 @@ def _fake_read_for_get_pom_test(path):
 def _fake_download(url, output):
     pass
 
+def _fake_log(string):
+    pass
+
 # This test is way way too mock-ish, but I definitely wanted to stage a test around the method itself, since I'm
 # restructuring large chunks of the code.  All it does is make sure the download and execute commands are done
 # as expected, to return pom text.
@@ -40,7 +43,8 @@ def get_pom_test(env):
     fake_ctx = struct(
         download = _fake_download,
         read = _fake_read_for_get_pom_test,
-        attr = struct(repository_urls = [_FAKE_URL_PREFIX])
+        attr = struct(repository_urls = [_FAKE_URL_PREFIX], insecure_pom_cache = None),
+        report_progress = _fake_log,
     )
     project = poms.parse(
         for_testing.fetch_pom(fake_ctx, artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))))
@@ -64,7 +68,8 @@ def get_parent_chain_test(env):
     fake_ctx = struct(
         download = _fake_download,
         read = _fake_read_for_get_parent_chain,
-        attr = struct(repository_urls = [_FAKE_URL_PREFIX])
+        attr = struct(repository_urls = [_FAKE_URL_PREFIX], insecure_pom_cache = None),
+        report_progress = _fake_log,
     )
     chain = for_testing.get_inheritance_chain(fake_ctx, COMPLEX_POM)
     asserts.equals(env, ["child", "parent", "grandparent"], [_extract_artifact_id(x) for x in chain])

--- a/maven/tests/maven_test.bzl
+++ b/maven/tests/maven_test.bzl
@@ -51,7 +51,7 @@ def get_pom_test(env):
     fake_ctx = struct(
         download = _noop_download,
         read = _fake_read_for_get_pom_test,
-        attr = struct(repository_urls = [_FAKE_URL_PREFIX], insecure_pom_cache = None),
+        attr = struct(repository_urls = [_FAKE_URL_PREFIX], cache_poms_insecurely = False),
         report_progress = _noop_report_progress,
     )
     project = poms.parse(
@@ -61,18 +61,20 @@ def get_pom_test(env):
 
 def _fake_execute_for_cache_hit_test(args):
     if args[0] == "cat":
-        if args[1] == "/tmp/blah/test/group/child-1.0.pom.sha256":
+        if args[1] == "/tmp/blah/sha256/test/group/child-1.0.pom.sha256":
             return struct(
                 return_code = 0,
                 stdout = "\n1234567812345678123456781234567812345678123456781234567812345678 \n",
             )
+    fail("Unexpected Execution %s" % args)
 
 def get_pom_sha256_cache_hit_test(env):
     fake_ctx = struct(
         download = _noop_download,
         read = _fake_execute_for_cache_hit_test,
         attr = struct(
-            insecure_pom_cache = "/tmp/blah",
+            cache_poms_insecurely = True,
+            insecure_cache = "/tmp/blah",
             pom_sha256_hashes = {},
         ),
         report_progress = _noop_report_progress,
@@ -90,11 +92,11 @@ def _fake_download_for_cache_miss_test(url, output):
 def _fake_execute_for_cache_miss_test(args):
     print(args)
     if args[0] == "cat":
-        if args[1] == "/tmp/blah/test/group/child-1.0.pom.sha256":
+        if args[1] == "/tmp/blah/sha256/test/group/child-1.0.pom.sha256":
             return struct(return_code = 1)
     elif args[0] == "bin/pom_hash_cache_write.sh":
         if (args[1] == "1234567812345678123456781234567812345678123456781234567812345678" and
-            args[2] == "/tmp/blah/test/group/child-1.0.pom.sha256"):
+            args[2] == "/tmp/blah/sha256/test/group/child-1.0.pom.sha256"):
             return struct(return_code = 0)
     fail("Unexpected Execution %s" % args)
 
@@ -103,7 +105,8 @@ def get_pom_sha256_cache_miss_test(env):
         download = _fake_download_for_cache_miss_test,
         read = _fake_read_for_get_pom_test,
         attr = struct(
-            insecure_pom_cache = "/tmp/blah",
+            cache_poms_insecurely = True,
+            insecure_cache = "/tmp/blah",
             pom_sha256_hashes = {},
         ),
         report_progress = _noop_report_progress,
@@ -120,7 +123,7 @@ def get_pom_sha256_predefined_test(env):
         download = _fake_download_for_cache_miss_test,
         read = _fake_read_for_get_pom_test,
         attr = struct(
-            insecure_pom_cache = "/tmp/blah",
+            insecure_cache = "/tmp/blah",
             pom_sha256_hashes = {
                 "test.group:child:1.0": "1234567812345678123456781234567812345678123456781234567812345678",
             },
@@ -148,7 +151,7 @@ def get_parent_chain_test(env):
     fake_ctx = struct(
         download = _noop_download,
         read = _fake_read_for_get_parent_chain,
-        attr = struct(repository_urls = [_FAKE_URL_PREFIX], insecure_pom_cache = None),
+        attr = struct(repository_urls = [_FAKE_URL_PREFIX], cache_poms_insecurely = False),
         report_progress = _noop_report_progress,
     )
     chain = for_testing.get_inheritance_chain(fake_ctx, COMPLEX_POM)

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -41,11 +41,25 @@ kt_register_toolchains()
 
 maven_repository_specification(
     name = "maven",
+
+    # If supplied, then any pom files for which a pom_sha256 attribute is not supplied will be
+    # insecurely cached (after first download) using hashes stored in this folder.
+    #
+    # This can be an absolute or a path relative to ${HOME}
+    insecure_pom_cache=".cache/bazel_pom_cache",
+
+    # The artifact spec list.
     artifacts = {
         # This is the proper way to specify an artifact.  It contains the artifact, plus a configuration dictionary.
         # The config dictionary contains a sha256 hash. This both ensures the file downloaded is the expected one, but
-        # also caches the file in bazel's "content addressable" cache, which survives build clean. 
-        "com.google.guava:guava:25.0-jre": {"sha256": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9"},
+        # also caches the file in bazel's "content addressable" cache, which survives build clean.
+        "com.google.guava:guava:25.0-jre": {
+            "sha256": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9",
+
+            # This is optional, but more secure. Failing this, the pom's sha will be locally
+            # stored in the insecure_pom_cache
+            "pom_sha256": "68c1ac2817572d6a6eb5c36072c37379f912ec75e99f6bc25aaa7ed2eb2b5ff1",
+        },
         "com.google.dagger:dagger:2.20": {
             "sha256": "d37a556d8d57e2428c20e222b95346512d11fcf2174d581489a69a1439b886fb",
             "build_snippet": DAGGER_BUILD_SNIPPET_WITH_PLUGIN.format(version = "2.20"),
@@ -85,6 +99,7 @@ maven_repository_specification(
         "org.reflections:reflections:0.9.11": { "insecure": True }, # test leniency related to #62.
         "org.javassist:javassist:3.21.0-GA": { "insecure": True}, # Only needed if #62 is fixed.
     },
+
     # Because these apply to all targets within a group, it's specified separately from the artifact list.
     dependency_target_substitutes = {
         # Because we rewrite dagger -> dagger_api (and make a wrapper target "dagger" that exports the dagger

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -42,11 +42,14 @@ kt_register_toolchains()
 maven_repository_specification(
     name = "maven",
 
-    # If supplied, then any pom files for which a pom_sha256 attribute is not supplied will be
+    # If true, then any pom files for which a pom_sha256 attribute is not supplied will be
     # insecurely cached (after first download) using hashes stored in this folder.
+    cache_poms_insecurely = True, # default False
+
+    # If supplied, this will be the alternate location for insecure sha hashes.
     #
     # This can be an absolute or a path relative to ${HOME}
-    insecure_pom_cache=".cache/bazel_pom_cache",
+    insecure_cache=".cache/bazel_maven_repository", # This is the default
 
     # The artifact spec list.
     artifacts = {


### PR DESCRIPTION
This feature adds a facility for caching pom files in the content addressable (CA) cache. This can be done securely or insecurely.

In secure mode, one adds `pom_sha256` items to each artifact, and they are downloaded with the caching behavior typical of bazel downloads.  Poms not so listed are downloaded anew each time, displaying their SHA hashes on the console, as before.  Note that there is no facility (at this time) of specifying the sha for parent poms, these being different artifacts.  A later feature will add this.

In insecure mode, the user can supply a cache directory (typically something like `.cache/bazel_maven_repository/pom_hashes`) as a repository-level configuration.  In this case, the first time .pom files are downloaded, their sha256 hashes are cached in that directory.  On subsequent runs where the poms would normally be downloaded, their sha256 hashes are loaded from this cache and they are downloaded as if the hash had been configured in the artifact specification.

The visual noise is thereby reduced, as is additional download costs.  These are small files, so the costs are typically minimal, but it can add up, especially in low-network conditions. 

Fixes #51