### PR TITLE
Support dependency exclusions as a first class configuration option.

### DIFF
--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -278,7 +278,8 @@ def _generate_maven_repository_impl(ctx):
                         list(unregistered_deps),
                     ))
                 test_only_subst = (
-                    "\n    testonly = True," if sets.contains(test_only_artifacts, spec) else "")
+                    "\n    testonly = True," if sets.contains(test_only_artifacts, spec) else ""
+                )
 
                 target_definitions.append(
                     _MAVEN_REPO_TARGET_TEMPLATE.format(
@@ -309,7 +310,6 @@ _generate_maven_repository = repository_rule(
         "exclusions": attr.string_list_dict(mandatory = True),
     },
 )
-
 
 # Implementation of the maven_jvm_artifact rule.
 def _maven_jvm_artifact(artifact_spec, name, visibility, deps = [], **kwargs):

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -75,7 +75,11 @@ maven_repository_specification(
         "com.google.code.findbugs:jsr305:3.0.2": {"insecure": True},
         "com.google.errorprone:javac-shaded:9+181-r4173-1": {"insecure": True},
         "com.google.googlejavaformat:google-java-format:1.6": {"insecure": True},
-        "com.google.truth:truth:0.42": {"insecure": True, "testonly": True},
+        "com.google.truth:truth:0.42": {
+            "insecure": True,
+            "testonly": True,
+            "exclude": ["org.checkerframework:checker-qual"], # for demonstration - don't alter truth in a real project.
+        },
         "com.squareup:javapoet:1.11.1": {"insecure": True},
         "io.reactivex.rxjava2:rxjava:2.2.6": {"insecure": True},
         "org.reactivestreams:reactive-streams:1.0.2": {"insecure": True},


### PR DESCRIPTION
This should reduce the need for build_snippet usage.

Fixes #74