### PR TITLE
Infer the packaging type from the pom.

### DIFF
--- a/maven/artifacts.bzl
+++ b/maven/artifacts.bzl
@@ -1,14 +1,7 @@
 #
 # Utilities for processing maven artifact coordinates and generating useful structs.
 #
-
-# Artifact types supported by maven_jvm_artifact()
-_supported_jvm_artifact_packaging = [
-    "jar",
-    "aar",
-]
-# All supported artifact types (Can be extended for non-jvm packaging types.)
-_supported_artifact_packaging = _supported_jvm_artifact_packaging
+load(":utils.bzl", "strings")
 
 _artifact_template = "{group_path}/{artifact_id}/{version}/{artifact_id}-{version}.{suffix}"
 _artifact_template_with_classifier = "{group_path}/{artifact_id}/{version}/{artifact_id}-{version}-{classifier}.{suffix}"
@@ -17,7 +10,7 @@ _artifact_pom_template = "{group_path}/{artifact_id}/{version}/{artifact_id}-{ve
 # Builds a struct containing the basic coordinate elements of a maven artifact spec.
 def _parse_spec(artifact_spec):
     parts = artifact_spec.split(":")
-    packaging = "jar"
+    type = "jar"
     classifier = None
     version = "UNKNOWN"
 
@@ -27,9 +20,9 @@ def _parse_spec(artifact_spec):
     elif len(parts) == 3:
         group_id, artifact_id, version = parts
     elif len(parts) == 4:
-        group_id, artifact_id, version, packaging = parts
+        group_id, artifact_id, version, type = parts
     elif len(parts) == 5:
-        group_id, artifact_id, version, packaging, classifier = parts
+        group_id, artifact_id, version, type, classifier = parts
     else:
         fail("Invalid artifact: %s" % artifact_spec)
 
@@ -37,27 +30,21 @@ def _parse_spec(artifact_spec):
         original_spec = artifact_spec,
         group_id = group_id,
         artifact_id = artifact_id,
-        packaging = packaging,
+        type = type,
         classifier = classifier,
         version = version,
     )
 
-def _munge_target(artifact_id):
-    return artifact_id.replace("-", "_").replace(".", "_")
 
 # Builds an annotated struct from a more basic artifact struct, with standard paths, names, and other values
 # derived from the basic artifact spec elements.
 def _annotate_artifact(artifact):
     if not bool(artifact.version):
         fail("Error, no version specified for %s:%s" % (artifact.group_id, artifact.artifact_id))
+
     # assemble paths and target names and such.
-    group_elements = artifact.group_id.split(".")
-    artifact_id_munged = _munge_target(artifact.artifact_id)
-    munged_classifier_if_present = (artifact.classifier.split("-") if artifact.classifier else [])
-    maven_target_elements = group_elements + [artifact_id_munged] + munged_classifier_if_present
-    maven_target_name = "_".join(maven_target_elements)
-    suffix = artifact.packaging # TODO(cgruber) support better packaging mapping, to handle .bundles etc.
-    group_path = "/".join(group_elements)
+    suffix = artifact.type
+    group_path = "/".join(artifact.group_id.split("."))
     if bool(artifact.classifier):
         path = None if not bool(artifact.version) else _artifact_template_with_classifier.format(
             group_path = group_path,
@@ -80,15 +67,14 @@ def _annotate_artifact(artifact):
     ) if bool(artifact.version) else None
 
     annotated_artifact = struct(
-        maven_target_name = maven_target_name,
-        third_party_target_name = artifact_id_munged,
+        third_party_target_name = strings.munge(artifact.artifact_id),
         path = path,
         group_path = group_path,
         pom = pom,
         original_spec = artifact.original_spec,
         group_id = artifact.group_id,
         artifact_id = artifact.artifact_id,
-        packaging = artifact.packaging,
+        type = artifact.type,
         classifier = artifact.classifier,
         version = artifact.version,
     )
@@ -97,5 +83,4 @@ def _annotate_artifact(artifact):
 artifacts = struct(
     parse_spec = _parse_spec,
     annotate = _annotate_artifact,
-    munge_target = _munge_target,
 )

--- a/maven/constants.bzl
+++ b/maven/constants.bzl
@@ -1,5 +1,0 @@
-#
-# Constants shared across the whole infrastructure.  Local constants should stay defined in their own file.
-#
-
-DOWNLOAD_PREFIX = "maven"

--- a/maven/fetch.bzl
+++ b/maven/fetch.bzl
@@ -30,19 +30,10 @@ echo "${content}" > ${cache_file}
 def _format_exported_files(paths):
     return "".join(["    \"%s\",\n" % path for path in paths])
 
-# The local path to the artifact/version subfolder in which all files should be found, according to
-# the standard maven layout
-def _artifact_parent_path(artifact):
-    return "{group_id}/{artifact_id}/{version}".format(
-        group_id = artifact.group_path,
-        artifact_id = artifact.artifact_id,
-        version = artifact.version,
-    )
-
 def _get_packaging_type(ctx, pom_label):
     packaging_type_file = pom_label.relative(":%s" % PACKAGING_TYPE_FILE)
     path = ctx.path(packaging_type_file)
-    result = ctx.execute(["cat", path])
+    result = ctx.execute(["cat", path])  # TODO(cgruber) Convert to read post Bazel 0.29
     if result.return_code != 0:
         fail("Failed to retreive packaging type from %s for artifact %s: %s" % (
             packaging_type_file,
@@ -98,7 +89,7 @@ def _get_pom_sha256(ctx, artifact, urls, file):
     else:
         cache_dir = "%s/%s/%s" % (ctx.os.environ["HOME"], ctx.attr.insecure_cache, _POM_HASH_INFIX)
     cached_file = "%s/%s.sha256" % (cache_dir, file)
-    sha_cache_result = ctx.execute(["cat", cached_file])
+    sha_cache_result = ctx.execute(["cat", cached_file])  # TODO(cgruber) Convert to read post Bazel 0.29
     if sha_cache_result.return_code != 0:
         # This will result in a CA cache miss and an extra download on first use, since the first
         # (non-sha-attributed) download won't store anything in the CA cache.

--- a/maven/fetch.bzl
+++ b/maven/fetch.bzl
@@ -1,47 +1,174 @@
-load(":constants.bzl", "DOWNLOAD_PREFIX")
+#
+# Description:
+#   Utilities and rules concerning the actual fetch of artifacts and sub-artifacts and metadata.
+#
+load(":artifacts.bzl", "artifacts")
+load(":globals.bzl", "DOWNLOAD_PREFIX", "PACKAGING_TYPE_FILE", "fetch_repo")
+load(":packaging_type.bzl", "packaging_type")
+load(":poms.bzl", "poms")
+load(":utils.bzl", "strings")
+load(":xml.bzl", "xml")
 
 _ARTIFACT_DOWNLOAD_BUILD_FILE_TEMPLATE = """
 package(default_visibility = ["//visibility:public"])
 exports_files([
-    "{path}",
-])
+{files}])
 """
 
-# Validate that the path being fetched isn't a bazel-critical file we need to write.
-def _validate_path(ctx, path):
-    forbidden = [
-        ctx.path("."),
-        ctx.path("WORKSPACE"),
-        ctx.path("BUILD"),
-        ctx.path("BUILD.bazel"),
-        ctx.path("%s/BUILD" % DOWNLOAD_PREFIX),
-        ctx.path("%s/BUILD.bazel" % DOWNLOAD_PREFIX),
-    ]
-    if path in forbidden or not str(path).startswith(str(ctx.path("."))):
-        fail("Invalid local_path: %s" % ctx.attr.local_path)
-    return path
+_POM_HASH_INFIX = "sha256"
+
+_POM_HASH_CACHE_WRITE_SCRIPT = "bin/pom_hash_cache_write.sh"
+
+#TODO(cgruber) move this into a toolchain (and make a windows equivalent)
+_POM_HASH_CACHE_WRITE_SCRIPT_CONTENT = """#!/bin/sh
+content="$1"
+cache_file="$2"
+mkdir -p $(dirname "${cache_file}")
+echo "${content}" > ${cache_file}
+"""
+
+def _format_exported_files(paths):
+    return "".join(["    \"%s\",\n" % path for path in paths])
+
+# The local path to the artifact/version subfolder in which all files should be found, according to
+# the standard maven layout
+def _artifact_parent_path(artifact):
+    return "{group_id}/{artifact_id}/{version}".format(
+        group_id = artifact.group_path,
+        artifact_id = artifact.artifact_id,
+        version = artifact.version,
+    )
+
+def _get_packaging_type(ctx, pom_label):
+    packaging_type_file = pom_label.relative(":%s" % PACKAGING_TYPE_FILE)
+    path = ctx.path(packaging_type_file)
+    result = ctx.execute(["cat", path])
+    if result.return_code != 0:
+        fail("Failed to retreive packaging type from %s for artifact %s: %s" % (
+            packaging_type_file,
+            ctx.attr.artifact,
+            result.stderr,
+        ))
+    return strings.trim(result.stdout)
 
 # Downloads an artifact and exports it into the build language.
-# TODO: consume an artifact spec and a metadata file label, and infer information like path and file extension.
 def _fetch_artifact_impl(ctx):
-    local_path = "%s/%s" % (DOWNLOAD_PREFIX, ctx.attr.local_path)
-    download_path = _validate_path(ctx, ctx.path(local_path))
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
+    artifact = artifacts.parse_spec(ctx.attr.artifact)
+    packaging = packaging_type.value_of(_get_packaging_type(ctx, ctx.attr.pom))
+    path = fetch_repo.artifact_path(artifact, packaging.suffix)
+    urls = ["%s/%s" % (repo, path) for repo in ctx.attr.repository_urls]
+    local_path = "%s/%s" % (DOWNLOAD_PREFIX, path)
     ctx.file(
         "%s/BUILD.bazel" % DOWNLOAD_PREFIX,
-        _ARTIFACT_DOWNLOAD_BUILD_FILE_TEMPLATE.format(prefix = DOWNLOAD_PREFIX, path = ctx.attr.local_path),
+        _ARTIFACT_DOWNLOAD_BUILD_FILE_TEMPLATE.format(files = _format_exported_files([path])),
     )
-    ctx.download(url = ctx.attr.urls, output = local_path, sha256 = ctx.attr.sha256)
+    ctx.download(url = urls, output = local_path, sha256 = ctx.attr.sha256)
 
-_fetch_artifact = repository_rule(
+fetch_artifact = repository_rule(
     implementation = _fetch_artifact_impl,
     attrs = {
-        "local_path": attr.string(),
+        "artifact": attr.string(),
         "sha256": attr.string(),
-        "urls": attr.string_list(mandatory = True),
+        "repository_urls": attr.string_list(),
+        "pom": attr.label(),
+    },
+)
+# Try to obtain the sha256 of the pom file, so it can be resolved from the CA cache (if
+# present).
+#
+# Note, this is strictly insecure, insofar as we are trusting the first download and caching the
+# sha of the file first downloaded.  However, this is not the artifact, and even if hostile pom
+# metadata were introduced, it could only point at dependencies listed in the master list, or else
+# errors will be surfaced, so there is a signal that something has intercepted.  More rigorous
+# usage is possible by setting the pom_sha256 property in the configuration of the artifact.
+def _get_pom_sha256(ctx, artifact, urls, file):
+    ctx.report_progress("Obtaining hash for %s" % file)
+
+    explicit_hash = ctx.attr.pom_hashes.get(artifact.original_spec)
+    if bool(explicit_hash):
+        return explicit_hash
+
+    if not ctx.attr.cache_poms_insecurely:
+        return None
+
+    # Fetch from the cache.
+    if ctx.attr.insecure_cache.startswith("/"):
+        cache_dir = "%s/%s" % (ctx.attr.insecure_cache, _POM_HASH_INFIX)
+    else:
+        cache_dir = "%s/%s/%s" % (ctx.os.environ["HOME"], ctx.attr.insecure_cache, _POM_HASH_INFIX)
+    cached_file = "%s/%s.sha256" % (cache_dir, file)
+    sha_cache_result = ctx.execute(["cat", cached_file])
+    if sha_cache_result.return_code != 0:
+        # This will result in a CA cache miss and an extra download on first use, since the first
+        # (non-sha-attributed) download won't store anything in the CA cache.
+        ctx.report_progress("%s not locally cached, fetching and hashing" % cached_file)
+        pom_result = ctx.download(url = urls, output = file)
+        result = ctx.execute([_POM_HASH_CACHE_WRITE_SCRIPT, pom_result.sha256, cached_file])
+        if result.return_code != 0:
+            fail("Cache write failed with code %s, stderr: %s", (result.return_code, result.stderr))
+        return pom_result.sha256
+    else:
+        return strings.trim(sha_cache_result.stdout)
+
+# Fetch the pom for the artifact.  First see if a cached hash is available for it. If so, use
+# that hash to try a download with the sha, to get a hit on the content addressable cache. If not
+# fetch normally and write that hash to the pom hash cache for next time.
+def _fetch_and_read_pom(ctx, artifact):
+    path = fetch_repo.pom_path(artifact)
+    local_path = "%s/%s" % (DOWNLOAD_PREFIX, path)
+    ctx.report_progress("Fetching %s" % path)
+    urls = ["%s/%s" % (repo, path) for repo in ctx.attr.repository_urls]
+    sha256 = _get_pom_sha256(ctx, artifact, urls, path)
+    if sha256:
+        ctx.download(url = urls, sha256 = sha256, output = local_path)
+    else:
+        ctx.download(url = urls, output = local_path)
+    return ctx.read(local_path)
+
+
+def _fetch_pom_impl(ctx):
+    ctx.file(
+        _POM_HASH_CACHE_WRITE_SCRIPT,
+        content = _POM_HASH_CACHE_WRITE_SCRIPT_CONTENT,
+        executable = True,
+    )
+    ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
+
+    # Fetch this pom and its parent poms.
+    paths = [PACKAGING_TYPE_FILE]
+    packaging_type = None
+    current = artifacts.parse_spec(ctx.attr.artifact)
+    for count in range(10):
+        if not bool(current):
+            break
+        xml_text = _fetch_and_read_pom(ctx, current)
+        paths.append(fetch_repo.pom_path(current))
+        project = poms.parse(xml_text)
+        if count == 0:
+            packaging_type = poms.extract_packaging(project)
+        current = poms.extract_parent(project)
+    if not bool(packaging_type):
+        fail("Could not determine packaging type from root pom for %s" % ctx.attr.artifact)
+    ctx.file("%s/%s" % (DOWNLOAD_PREFIX, PACKAGING_TYPE_FILE), packaging_type)
+
+    ctx.file(
+        "%s/BUILD.bazel" % DOWNLOAD_PREFIX,
+        _ARTIFACT_DOWNLOAD_BUILD_FILE_TEMPLATE.format(files = _format_exported_files(paths)),
+    )
+
+fetch_pom = repository_rule(
+    implementation = _fetch_pom_impl,
+    attrs = {
+        "artifact": attr.string(),
+        "pom_hashes": attr.string_dict(),
+        "repository_urls": attr.string_list(),
+        "cache_poms_insecurely": attr.bool(),
+        "insecure_cache": attr.string(mandatory = False),
     },
 )
 
-fetch = struct(
-    artifact = _fetch_artifact,
+for_testing = struct(
+    fetch_and_read_pom = _fetch_and_read_pom,
+    get_pom_sha256 = _get_pom_sha256,
 )

--- a/maven/globals.bzl
+++ b/maven/globals.bzl
@@ -1,0 +1,60 @@
+#
+# Values and global functions shared across the whole infrastructure.  Local constants should stay defined in their
+# own file.  This file includes functions with shared business logic, whereas pure utilities should go in utils, etc.
+#
+load(":utils.bzl", "strings")
+
+DOWNLOAD_PREFIX = "maven"
+PACKAGING_TYPE_FILE = "packaging_type"
+
+_REPO_PREFIX = "maven_fetch"
+
+def _group_path(artifact):
+    return "/".join(artifact.group_id.split("."))
+
+def _artifact_repo_name(artifact):
+    # Extra empty strings are there to force "__" in between sections (to disambiguate
+    # "foo:bar-parent:1.0" from "foo.bar:parent:1.0" in fetch repos.
+    artifact_id_munged = strings.munge(artifact.artifact_id)
+    munged_classifier_if_present = [strings.munge(artifact.classifier.split)] if artifact.classifier else []
+    group_elements = artifact.group_id.split(".")
+    return "_".join([_REPO_PREFIX, ""] + group_elements + ["", artifact_id_munged] + munged_classifier_if_present)
+
+def _pom_repo_name(artifact):
+    return "%s__pom" % _artifact_repo_name(artifact)
+
+# The local path to a pom according to the standard maven layout.
+def _artifact_path(artifact, suffix):
+    return "{group_id}/{artifact_id}/{version}/{artifact_id}-{version}.{suffix}".format(
+        group_id = _group_path(artifact),
+        artifact_id = artifact.artifact_id,
+        version = artifact.version,
+        suffix = suffix,
+    )
+
+# The local path to a pom according to the standard maven layout.
+def _pom_path(artifact):
+    return "{group_id}/{artifact_id}/{version}/{artifact_id}-{version}.pom".format(
+        group_id = _group_path(artifact),
+        artifact_id = artifact.artifact_id,
+        version = artifact.version,
+    )
+
+def _artifact_target(artifact, suffix):
+    return Label("@%s//%s:%s" % (_artifact_repo_name(artifact), DOWNLOAD_PREFIX, _artifact_path(artifact, suffix)))
+
+def _pom_target(artifact):
+    return _pom_target_relative_to(artifact, _pom_repo_name(artifact))
+
+def _pom_target_relative_to(artifact, workspace):
+    return Label("@%s//%s:%s" % (workspace, DOWNLOAD_PREFIX, _pom_path(artifact)))
+
+fetch_repo = struct(
+    artifact_path = _artifact_path,
+    artifact_repo_name = _artifact_repo_name,
+    artifact_target = _artifact_target,
+    pom_path = _pom_path,
+    pom_target = _pom_target,
+    pom_target_relative_to = _pom_target_relative_to,
+    pom_repo_name = _pom_repo_name,
+)

--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -15,9 +15,10 @@
 #   A repository rule intended to be used in populating @maven_repository.
 #
 load(":artifacts.bzl", artifact_utils = "artifacts")
-load(":constants.bzl", "DOWNLOAD_PREFIX")
-load(":fetch.bzl", "fetch")
+load(":globals.bzl", "DOWNLOAD_PREFIX", "fetch_repo")
+load(":fetch.bzl", "fetch_pom", "fetch_artifact")
 load(":jvm.bzl", "raw_jvm_import")
+load(":packaging_type.bzl", "packaging_type")
 load(":poms.bzl", "poms")
 load(":sets.bzl", "sets")
 load(":utils.bzl", "dicts", "paths", "strings")
@@ -48,18 +49,6 @@ artifacts = {
 _LEGACY_BUILD_SUBSTITUTIONS_DEPRECATION_WARNING = """WARNING: Passing the build snippet via build_substitutes is deprecated.
 Please pass the snippet for %s as a configuration property in the artifact dictionary."""
 
-_POM_HASH_CACHE_WRITE_SCRIPT = "bin/pom_hash_cache_write.sh"
-
-#TODO(cgruber) move this into a toolchain (and make a windows equivalent)
-_POM_HASH_CACHE_WRITE_SCRIPT_CONTENT = """#!/bin/sh
-content="$1"
-cache_file="$2"
-mkdir -p $(dirname "${cache_file}")
-echo "${content}" > ${cache_file}
-"""
-
-_POM_HASH_INFIX = "sha256"
-
 _MAVEN_REPO_BUILD_PREFIX = """# Generated bazel build file for maven group {group_id}
 
 load("@{maven_rules_repository}//maven:maven.bzl", "maven_jvm_artifact")
@@ -68,12 +57,13 @@ load("@{maven_rules_repository}//maven:maven.bzl", "maven_jvm_artifact")
 _MAVEN_REPO_TARGET_TEMPLATE = """maven_jvm_artifact(
     name = "{target}",{test_only}
     artifact = "{artifact_coordinates}",
+    type = "{type}",
 {deps})
 """
 
 def _convert_maven_dep(repo_name, artifact):
     group_path = artifact.group_id.replace(".", "/")
-    target = artifact_utils.munge_target(artifact.artifact_id)
+    target = strings.munge(artifact.artifact_id)
     return "@{repo}//{group_path}:{target}".format(repo = repo_name, group_path = group_path, target = target)
 
 def _normalize_target(full_target_spec, current_package, target_substitutions):
@@ -83,89 +73,6 @@ def _normalize_target(full_target_spec, current_package, target_substitutions):
     if local_package == current_package:
         return ":%s" % target  # Trim to a local reference.
     return full_package if paths.filename(full_package) == target else full_target_spec
-
-# Try to obtain the sha256 of the pom file, so it can be resolved from the CA cache (if
-# present).
-#
-# Note, this is strictly insecure, insofar as we are trusting the first download and caching the
-# sha of the file first downloaded.  However, this is not the artifact, and even if hostile pom
-# metadata were introduced, it could only point at dependencies listed in the master list, or else
-# errors will be surfaced, so there is a signal that something has intercepted.  More rigorous
-# usage is possible by setting the pom_sha256 property in the configuration of the artifact.
-def _get_pom_sha256(ctx, artifact, urls, file):
-    ctx.report_progress("Obtaining hash for %s" % file)
-    explicit_sha256 = ctx.attr.pom_sha256_hashes.get(artifact.original_spec)
-    if explicit_sha256:
-        return explicit_sha256
-    if ctx.attr.insecure_cache.startswith("/"):
-        cache_dir = "%s/%s" % (ctx.attr.insecure_cache, _POM_HASH_INFIX)
-    else:
-        cache_dir = "%s/%s/%s" % (ctx.os.environ["HOME"], ctx.attr.insecure_cache, _POM_HASH_INFIX)
-    cached_file = "%s/%s.sha256" % (cache_dir, file)
-    sha_cache_result = ctx.execute(["cat", cached_file])
-    if sha_cache_result.return_code != 0:
-        # This will result in a CA cache miss and an extra download on first use, since the first
-        # (non-sha-attributed) download won't store anything in the CA cache.
-        ctx.report_progress("%s not locally cached, fetching and hashing" % cached_file)
-        pom_result = ctx.download(url = urls, output = file)
-        result = ctx.execute([_POM_HASH_CACHE_WRITE_SCRIPT, pom_result.sha256, cached_file])
-        if result.return_code != 0:
-            fail("Cache write failed with code %s, stderr: %s", (result.return_code, result.stderr))
-        return pom_result.sha256
-    else:
-        return strings.trim(sha_cache_result.stdout)
-
-# Fetch the pom for the artifact.  First see if a cached hash is available for it. If so, use
-# that hash to try a download with the sha, to get a hit on the content addressable cache. If not
-# fetch normally and write that hash to the pom hash cache for next time.
-#
-# This should be in poms.bzl, but we want to keep ctx/network/file operations separate,
-# and Starlark is constrained enough that creating a "downloader" struct is more trouble than
-# it's worth.
-def _fetch_pom(ctx, artifact):
-    urls = ["%s/%s" % (repo, artifact.pom) for repo in ctx.attr.repository_urls]
-    file = "{group_id}/{artifact_id}-{version}.pom".format(
-        group_id = artifact.group_path,
-        artifact_id = artifact.artifact_id,
-        version = artifact.version,
-    )
-    ctx.report_progress("Fetching %s" % file)
-
-    sha256 = _get_pom_sha256(ctx, artifact, urls, file) if ctx.attr.cache_poms_insecurely else None
-    if sha256:
-        ctx.download(url = urls, sha256 = sha256, output = file)
-    else:
-        ctx.download(url = urls, output = file)
-    return ctx.read(file)
-
-# In theory, this logic should live in poms.bzl, but bazel makes it harder to use the strategy pattern (to pass in a
-# downloader) and we want to keep file and network code out of the poms processing code.
-def _get_inheritance_chain(ctx, xml_text):
-    inheritance_chain = [poms.parse(xml_text)]
-    current = inheritance_chain[0]
-    for _ in range(100):  # Can't use recursion, so just iterate
-        raw_parent_artifact = poms.extract_parent(current)
-        if not bool(raw_parent_artifact):
-            break
-        parent_artifact = artifact_utils.annotate(raw_parent_artifact)
-        parent_node = poms.parse(_fetch_pom(ctx, parent_artifact))
-        inheritance_chain += [parent_node]
-        current = parent_node
-    return inheritance_chain
-
-# Take an inheritance chain of xml trees (Fetched by _get_inheritance_chain) and merge them from
-# the top (the end of the list) to the bottom (the beginning of the list)
-def _get_effective_pom(inheritance_chain):
-    merged = inheritance_chain.pop()
-    for next in reversed(inheritance_chain):
-        merged = poms.merge_parent(parent = merged, child = next)
-    return merged
-
-# Extract the artifact's dependencies (accounting for pom inheritance), excluding those artifacts explicitly excluded.
-def _get_dependencies_from_pom_files(ctx, artifact):
-    inheritance_chain = _get_inheritance_chain(ctx, _fetch_pom(ctx, artifact))
-    project = _get_effective_pom(inheritance_chain)
-    return _get_dependencies_from_project(ctx, ctx.attr.exclusions.get(artifact.original_spec, []), project)
 
 def _get_dependencies_from_project(ctx, exclusions, project):
     exclusions = sets.copy_of(exclusions)
@@ -189,11 +96,6 @@ def _generate_maven_repository_impl(ctx):
     # Generate the root WORKSPACE file
     repository_root_path = ctx.path(".")
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
-    ctx.file(
-        _POM_HASH_CACHE_WRITE_SCRIPT,
-        content = _POM_HASH_CACHE_WRITE_SCRIPT_CONTENT,
-        executable = True,
-    )
 
     # Generate the per-group_id BUILD.bazel files.
     build_snippets = ctx.attr.build_snippets
@@ -222,7 +124,9 @@ def _generate_maven_repository_impl(ctx):
             if snippet:
                 target_definitions.append(snippet)
             else:
-                maven_deps = _get_dependencies_from_pom_files(ctx, artifact)
+                exclusions = ctx.attr.exclusions.get(artifact.original_spec, [])
+                pom = poms.get_project_metadata(ctx, artifact)
+                maven_deps = _get_dependencies_from_project(ctx, exclusions, pom)
                 maven_deps = [x for x in maven_deps if _should_include_dependency(x)]
                 found_artifacts = {}
                 bazel_deps = []
@@ -250,6 +154,7 @@ def _generate_maven_repository_impl(ctx):
                         target = artifact.third_party_target_name,
                         deps = _deps_string(normalized_deps),
                         artifact_coordinates = artifact.original_spec,
+                        type = poms.extract_packaging(pom),
                         test_only = test_only_subst,
                     ),
                 )
@@ -260,16 +165,13 @@ def _generate_maven_repository_impl(ctx):
 _generate_maven_repository = repository_rule(
     implementation = _generate_maven_repository_impl,
     attrs = {
-        "grouped_artifacts": attr.string_list_dict(mandatory = True),
-        "repository_urls": attr.string_list(mandatory = True),
+        "grouped_artifacts": attr.string_list_dict(),
         "maven_rules_repository": attr.string(mandatory = False, default = "maven_repository_rules"),
-        "dependency_target_substitutes": attr.string_list_dict(mandatory = True),
-        "build_snippets": attr.string_dict(mandatory = True),
-        "cache_poms_insecurely": attr.bool(mandatory = True),
-        "insecure_cache": attr.string(mandatory = False),
-        "pom_sha256_hashes": attr.string_dict(mandatory = True),
-        "test_only_artifacts": attr.string_list(mandatory = True),
-        "exclusions": attr.string_list_dict(mandatory = True),
+        "dependency_target_substitutes": attr.string_list_dict(),
+        "build_snippets": attr.string_dict(),
+        "test_only_artifacts": attr.string_list(),
+        "exclusions": attr.string_list_dict(),
+        "poms": attr.label_list(),
     },
 )
 
@@ -349,7 +251,6 @@ def _handle_legacy_specifications(artifacts, insecure_artifacts, build_snippets)
         print(_LEGACY_BUILD_SUBSTITUTIONS_DEPRECATION_WARNING % versioned_key)
     return artifacts
 
-
 ####################
 # PUBLIC FUNCTIONS #
 ####################
@@ -362,6 +263,9 @@ def maven_jvm_artifact(
         # The name of this target, typically the same as the artifact_id of the artifact.
         name = None,
 
+        # the packaging type (suffix) of the file
+        type = None,
+
         # Visibility of this target (default: ["//visibility:public"])
         visibility = ["//visibility:public"],
 
@@ -371,14 +275,15 @@ def maven_jvm_artifact(
         # Extra arguments passed through to the raw import rules that underly this macro.
         **kwargs):
     artifact_struct = artifact_utils.annotate(artifact_utils.parse_spec(artifact))
-    maven_target = "@%s//%s:%s" % (artifact_struct.maven_target_name, DOWNLOAD_PREFIX, artifact_struct.path)
+    artifact_type = packaging_type.value_of(type) if bool(type) else packaging_type.value_of(artifact_struct.type)
+    maven_target = fetch_repo.artifact_target(artifact_struct, artifact_type.suffix)
     target_name = name if name else artifact_struct.third_party_target_name
-    if artifact_struct.packaging == "jar":
+    if artifact_type.suffix == "jar":
         raw_jvm_import(name = target_name, deps = deps, visibility = visibility, jar = maven_target, **kwargs)
-    elif artifact_struct.packaging == "aar":
+    elif artifact_type.suffix == "aar":
         native.aar_import(name = target_name, deps = deps, visibility = visibility, aar = maven_target, **kwargs)
     else:
-        fail("Packaging %s not supported by maven_jvm_artifact." % artifact_struct.packaging)
+        fail("%s is not a supported artifact type. Currently only jar/aar are supported." % artifact_struct.type.name)
 
 # Description:
 #   Generates the bazel repo and download logic for each artifact (and repository URL prefixes) in the WORKSPACE
@@ -425,7 +330,6 @@ def maven_repository_specification(
         # addressable cache.  By default they are not cached locally unless pom_sha256 is supplied
         # for that artifact.
         insecure_cache = ".cache/bazel_maven_repository/hashes"):
-
     _handle_legacy_specifications(artifacts, insecure_artifacts, build_substitutes)
 
     if len(repository_urls) == 0:
@@ -441,28 +345,44 @@ def maven_repository_specification(
     pom_sha256_hashes = {}
     test_only_artifacts = []
     exclusions = {}
+    artifact_structs = {}
+    poms = []
+    # First pass, since some thing need to be globally available to each (like explicit pom shas)
     for artifact_spec, properties in artifacts.items():
-        artifact = artifact_utils.annotate(artifact_utils.parse_spec(artifact_spec))
+        artifact_structs[artifact_spec] = artifact_utils.annotate(artifact_utils.parse_spec(artifact_spec))
+        pom_hash = properties.get(artifact_config_properties.POM_SHA256)
+        if bool(pom_hash):
+            pom_sha256_hashes[artifact_spec] = pom_hash
 
+    for artifact_spec, properties in artifacts.items():
+        artifact = artifact_structs[artifact_spec]
         # Track group_ids in order to build per-group BUILD.bazel files.
         grouped_artifacts[artifact.group_id] = (
             grouped_artifacts.get(artifact.group_id, default = []) + [artifact.original_spec]
         )
-        sha256 = properties.get(artifact_config_properties.SHA256)
-        urls = ["%s/%s" % (repo, artifact.path) for repo in repository_urls]
-        fetch.artifact(
-            name = artifact.maven_target_name,
-            urls = urls,
-            local_path = artifact.path,
-            sha256 = sha256,
+        pom_sha256_hash = properties.get(artifact_config_properties.POM_SHA256)
+        fetch_pom(
+            name = fetch_repo.pom_repo_name(artifact),
+            artifact = artifact_spec,
+            repository_urls = repository_urls,
+            cache_poms_insecurely = cache_poms_insecurely,
+            insecure_cache = insecure_cache,
+            pom_hashes = pom_sha256_hashes,
         )
+        poms.append(fetch_repo.pom_target(artifact))
+
+        sha256 = properties.get(artifact_config_properties.SHA256)
+        fetch_artifact(
+            name = fetch_repo.artifact_repo_name(artifact),
+            artifact = artifact_spec,
+            repository_urls = repository_urls,
+            sha256 = sha256,
+            pom = fetch_repo.pom_target(artifact),
+        )
+
         snippet = properties.get(artifact_config_properties.BUILD_SNIPPET)
         if bool(snippet):
             build_snippets["%s:%s" % (artifact.group_id, artifact.artifact_id)] = snippet
-
-        pom_sha256_hash = properties.get(artifact_config_properties.POM_SHA256)
-        if bool(pom_sha256_hash):
-            pom_sha256_hashes[artifact_spec] = pom_sha256_hash
 
         if bool(properties.get(artifact_config_properties.TEST_ONLY)):
             test_only_artifacts += [artifact_spec]
@@ -476,16 +396,12 @@ def maven_repository_specification(
     _generate_maven_repository(
         name = name,
         grouped_artifacts = grouped_artifacts,
-        repository_urls = repository_urls,
         dependency_target_substitutes = dependency_target_substitutes_rewritten,
         build_snippets = build_snippets,
-        cache_poms_insecurely = cache_poms_insecurely,
-        insecure_cache = insecure_cache,
-        pom_sha256_hashes = pom_sha256_hashes,
         test_only_artifacts = test_only_artifacts,
         exclusions = exclusions,
+        poms = poms,
     )
-
 
 ####################
 # Test-only Struct #
@@ -493,9 +409,5 @@ def maven_repository_specification(
 for_testing = struct(
     unsupported_keys = _unsupported_keys,
     handle_legacy_specifications = _handle_legacy_specifications,
-    fetch_pom = _fetch_pom,
-    get_pom_sha256 = _get_pom_sha256,
-    get_inheritance_chain = _get_inheritance_chain,
-    get_effective_pom = _get_effective_pom,
     get_dependencies_from_project = _get_dependencies_from_project,
 )

--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -277,11 +277,10 @@ def maven_jvm_artifact(
     artifact_struct = artifact_utils.annotate(artifact_utils.parse_spec(artifact))
     artifact_type = packaging_type.value_of(type) if bool(type) else packaging_type.value_of(artifact_struct.type)
     maven_target = fetch_repo.artifact_target(artifact_struct, artifact_type.suffix)
-    target_name = name if name else artifact_struct.third_party_target_name
     if artifact_type.suffix == "jar":
-        raw_jvm_import(name = target_name, deps = deps, visibility = visibility, jar = maven_target, **kwargs)
+        raw_jvm_import(name = name, deps = deps, visibility = visibility, jar = maven_target, **kwargs)
     elif artifact_type.suffix == "aar":
-        native.aar_import(name = target_name, deps = deps, visibility = visibility, aar = maven_target, **kwargs)
+        native.aar_import(name = name, deps = deps, visibility = visibility, aar = maven_target, **kwargs)
     else:
         fail("%s is not a supported artifact type. Currently only jar/aar are supported." % artifact_struct.type.name)
 

--- a/maven/packaging_type.bzl
+++ b/maven/packaging_type.bzl
@@ -1,0 +1,22 @@
+# Artifact types supported by bazel maven repository
+
+_JAR = struct(name = "jar", suffix = "jar")
+_AAR = struct(name = "aar", suffix = "aar")
+_BUNDLE = struct(name = "bundle", suffix = "jar")
+_VALUES = [_JAR, _AAR, _BUNDLE]
+
+def _value_of_packaging_types(string):
+    for val in _VALUES:
+        if string == val.name:
+            return val
+    return None
+
+# enum
+packaging_type = struct(
+    JAR = _JAR,
+    AAR = _AAR,
+    BUNDLE = _BUNDLE,
+    DEFAULT = _JAR,
+    values = _VALUES,
+    value_of = _value_of_packaging_types,
+)

--- a/maven/tests/all_tests.bzl
+++ b/maven/tests/all_tests.bzl
@@ -1,4 +1,6 @@
 load(":dicts_test.bzl", dicts = "suite")
+load(":fetch_test.bzl", fetch = "suite")
+load(":globals_test.bzl", globals = "suite")
 load(":paths_test.bzl", paths = "suite")
 load(":maven_test.bzl", maven = "suite")
 load(":poms_test.bzl", poms = "suite")
@@ -10,7 +12,7 @@ load(":xml_test.bzl", xml = "suite")
 load("//maven:sets.bzl", "sets")
 
 
-SUITES = [dicts, paths, maven, poms, poms_merging, set_tests, strings, xml]
+SUITES = [dicts, fetch, globals, paths, maven, poms, poms_merging, set_tests, strings, xml]
 
 def _validate(ctx, suites):
     # Function objects don't have good properties, so we hack it from the string representation.

--- a/maven/tests/fetch_test.bzl
+++ b/maven/tests/fetch_test.bzl
@@ -1,0 +1,123 @@
+load(":poms_for_testing.bzl", "COMPLEX_POM", "GRANDPARENT_POM", "PARENT_POM")
+load(":testing.bzl", "asserts", "test_suite")
+load("//maven:artifacts.bzl", "artifacts")
+load("//maven:fetch.bzl", "for_testing")
+load("//maven:poms.bzl", "poms")
+load("//maven:sets.bzl", "sets")
+load("//maven:xml.bzl", "xml")
+
+_FAKE_URL_PREFIX = "fake://maven"
+_FAKE_DOWNLOAD_PREFIX = "maven"
+
+# Set up fakes.
+def _fake_read_for_fetch_and_read_pom_test(path):
+    return COMPLEX_POM
+
+def _noop_download(url, output):
+    pass
+
+def _noop_report_progress(string):
+    pass
+
+# This test is way way too mock-ish, but I definitely wanted to stage a test around the method itself, since I'm
+# restructuring large chunks of the code.  All it does is make sure the download and execute commands are done
+# as expected, to return pom text.
+def fetch_and_read_pom_test(env):
+    fake_ctx = struct(
+        download = _noop_download,
+        read = _fake_read_for_fetch_and_read_pom_test,
+        attr = struct(
+            repository_urls = [_FAKE_URL_PREFIX],
+            cache_poms_insecurely = False,
+            pom_hashes = {},
+        ),
+        report_progress = _noop_report_progress,
+    )
+    project = poms.parse(
+        for_testing.fetch_and_read_pom(fake_ctx, artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))),
+    )
+    asserts.equals(env, "project", project.label)
+
+def _fake_execute_for_cache_hit_test(args):
+    if args[0] == "cat":
+        if args[1] == "/tmp/blah/sha256/test/group/child-1.0.pom.sha256":
+            return struct(
+                return_code = 0,
+                stdout = "\n1234567812345678123456781234567812345678123456781234567812345678 \n",
+            )
+    fail("Unexpected Execution %s" % args)
+
+def get_pom_sha256_cache_hit_test(env):
+    fake_ctx = struct(
+        download = _noop_download,
+        read = _fake_execute_for_cache_hit_test,
+        attr = struct(
+            cache_poms_insecurely = True,
+            insecure_cache = "/tmp/blah",
+            pom_hashes = {},
+        ),
+        report_progress = _noop_report_progress,
+        execute = _fake_execute_for_cache_hit_test,
+    )
+    artifact = artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))
+    urls = ["fake://somerepo/test/group/child/1.0/child-1.0.pom"]
+    file = "test/group/child-1.0.pom"
+    sha256 = for_testing.get_pom_sha256(fake_ctx, artifact, urls, file)
+    asserts.equals(env, "1234567812345678123456781234567812345678123456781234567812345678", sha256)
+
+def _fake_download_for_cache_miss_test(url, output):
+    return struct(sha256 = "1234567812345678123456781234567812345678123456781234567812345678")
+
+def _fake_execute_for_cache_miss_test(args):
+    if args[0] == "cat":
+        if args[1] == "/tmp/blah/sha256/test/group/child-1.0.pom.sha256":
+            return struct(return_code = 1)
+    elif args[0] == "bin/pom_hash_cache_write.sh":
+        if (args[1] == "1234567812345678123456781234567812345678123456781234567812345678" and
+            args[2] == "/tmp/blah/sha256/test/group/child-1.0.pom.sha256"):
+            return struct(return_code = 0)
+    fail("Unexpected Execution %s" % args)
+
+def get_pom_sha256_cache_miss_test(env):
+    fake_ctx = struct(
+        download = _fake_download_for_cache_miss_test,
+        read = _fake_read_for_fetch_and_read_pom_test,
+        attr = struct(
+            cache_poms_insecurely = True,
+            insecure_cache = "/tmp/blah",
+            pom_hashes = {},
+        ),
+        report_progress = _noop_report_progress,
+        execute = _fake_execute_for_cache_miss_test,
+    )
+    artifact = artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))
+    urls = ["fake://somerepo/test/group/child/1.0/child-1.0.pom"]
+    file = "test/group/child-1.0.pom"
+    sha256 = for_testing.get_pom_sha256(fake_ctx, artifact, urls, file)
+    asserts.equals(env, "1234567812345678123456781234567812345678123456781234567812345678", sha256)
+
+def get_pom_sha256_predefined_test(env):
+    fake_ctx = struct(
+        download = _fake_download_for_cache_miss_test,
+        read = _fake_read_for_fetch_and_read_pom_test,
+        attr = struct(
+            insecure_cache = "/tmp/blah",
+            pom_hashes = {"test.group:child:1.0": "1234567812345678123456781234567812345678123456781234567812345678"},
+        ),
+        report_progress = _noop_report_progress,
+    )
+    artifact = artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))
+    sha256 = for_testing.get_pom_sha256(fake_ctx, artifact, None, None)
+    asserts.equals(env, "1234567812345678123456781234567812345678123456781234567812345678", sha256)
+
+# Roll-up function.
+def suite():
+    return test_suite(
+        "fetching",
+        tests = [
+            fetch_and_read_pom_test,
+            get_pom_sha256_cache_hit_test,
+            get_pom_sha256_cache_miss_test,
+            get_pom_sha256_predefined_test,
+        ],
+    )

--- a/maven/tests/globals_test.bzl
+++ b/maven/tests/globals_test.bzl
@@ -1,0 +1,67 @@
+load(":testing.bzl", "asserts", "test_suite")
+load("//maven:artifacts.bzl", "artifacts")
+load("//maven:globals.bzl", "fetch_repo")
+
+
+_artifact = artifacts.parse_spec("a.b:c:1.0")
+_parent = artifacts.parse_spec("a:c-d:1.0")
+
+def fetch_repo_pom_path_test(env):
+    asserts.equals(env, "a/b/c/1.0/c-1.0.pom", fetch_repo.pom_path(_artifact))
+    asserts.equals(env, "a/c-d/1.0/c-d-1.0.pom", fetch_repo.pom_path(_parent))
+
+def fetch_repo_pom_repo_name_test(env):
+    asserts.equals(env, "maven_fetch__a_b__c__pom", fetch_repo.pom_repo_name(_artifact))
+    asserts.equals(env, "maven_fetch__a__c_d__pom", fetch_repo.pom_repo_name(_parent))
+
+def fetch_repo_pom_target_test(env):
+    asserts.equals(env, Label("@maven_fetch__a_b__c__pom//maven:a/b/c/1.0/c-1.0.pom"), fetch_repo.pom_target(_artifact))
+    asserts.equals(env, Label("@maven_fetch__a__c_d__pom//maven:a/c-d/1.0/c-d-1.0.pom"), fetch_repo.pom_target(_parent))
+
+def fetch_pom_target_relative_to_test(env):
+    asserts.equals(
+        env,
+        expected = Label("@maven_fetch__a__c_d__pom//maven:a/b/c/1.0/c-1.0.pom"),
+        actual = fetch_repo.pom_target_relative_to(_artifact, fetch_repo.pom_repo_name(_parent))
+    )
+
+def differentiate_ambiguous_repo_names_test(env):
+    similarA = artifacts.parse_spec("foo:bar-baz:1.0")
+    similarB = artifacts.parse_spec("foo.bar:baz:1.0")
+    asserts.false(env, fetch_repo.pom_repo_name(similarA) == fetch_repo.pom_repo_name(similarB))
+    asserts.false(env, fetch_repo.pom_path(similarA) == fetch_repo.pom_path(similarB))
+
+def fetch_repo_artifact_path_test(env):
+    asserts.equals(env, "a/b/c/1.0/c-1.0.jar", fetch_repo.artifact_path(_artifact, "jar"))
+    asserts.equals(env, "a/b/c/1.0/c-1.0.aar", fetch_repo.artifact_path(_artifact, "aar"))
+
+def fetch_repo_artifact_repo_name_test(env):
+    asserts.equals(env, "maven_fetch__a_b__c", fetch_repo.artifact_repo_name(_artifact))
+    asserts.equals(env, "maven_fetch__a__c_d", fetch_repo.artifact_repo_name(_parent))
+
+def fetch_repo_artifact_target_test(env):
+    asserts.equals(
+        env,
+        expected = Label("@maven_fetch__a_b__c//maven:a/b/c/1.0/c-1.0.jar"),
+        actual = fetch_repo.artifact_target(_artifact, "jar")
+    )
+    asserts.equals(
+        env,
+        expected = Label("@maven_fetch__a_b__c//maven:a/b/c/1.0/c-1.0.aar"),
+        actual = fetch_repo.artifact_target(_artifact, "aar")
+    )
+
+TESTS = [
+    fetch_repo_pom_path_test,
+    fetch_repo_pom_repo_name_test,
+    fetch_repo_pom_target_test,
+    fetch_pom_target_relative_to_test,
+    differentiate_ambiguous_repo_names_test,
+    fetch_repo_artifact_path_test,
+    fetch_repo_artifact_repo_name_test,
+    fetch_repo_artifact_target_test,
+]
+
+# Roll-up function.
+def suite():
+    return test_suite("globals", tests = TESTS)

--- a/maven/tests/maven_test.bzl
+++ b/maven/tests/maven_test.bzl
@@ -2,7 +2,7 @@ load(":poms_for_testing.bzl", "COMPLEX_POM", "GRANDPARENT_POM", "PARENT_POM")
 load(":testing.bzl", "asserts", "test_suite")
 load("//maven:artifacts.bzl", "artifacts")
 load("//maven:maven.bzl", "for_testing")
-load("//maven:poms.bzl", "poms")
+load("//maven:poms.bzl", "poms", poms_testing = "for_testing")
 load("//maven:sets.bzl", "sets")
 load("//maven:xml.bzl", "xml")
 
@@ -35,8 +35,13 @@ def handle_legacy_build_snippet_handling(env):
     )
 
 # Set up fakes.
-def _fake_read_for_get_pom_test(path):
-    return COMPLEX_POM
+def _fake_read_for_get_parent_chain(args):
+    download_map = {
+        "test/group/child/1.0/child-1.0.pom": struct(return_code = 0, stdout = COMPLEX_POM),
+        "test/group/parent/1.0/parent-1.0.pom": struct(return_code = 0, stdout = PARENT_POM),
+        "test/grandparent/1.0/grandparent-1.0.pom": struct(return_code = 0, stdout = GRANDPARENT_POM),
+    }
+    return download_map.get(args[1], struct(return_code = 5, stderr = "ERROR!!!!!"))
 
 def _noop_download(url, output):
     pass
@@ -44,137 +49,19 @@ def _noop_download(url, output):
 def _noop_report_progress(string):
     pass
 
-# This test is way way too mock-ish, but I definitely wanted to stage a test around the method itself, since I'm
-# restructuring large chunks of the code.  All it does is make sure the download and execute commands are done
-# as expected, to return pom text.
-def get_pom_test(env):
-    fake_ctx = struct(
-        download = _noop_download,
-        read = _fake_read_for_get_pom_test,
-        attr = struct(repository_urls = [_FAKE_URL_PREFIX], cache_poms_insecurely = False),
-        report_progress = _noop_report_progress,
-    )
-    project = poms.parse(
-        for_testing.fetch_pom(fake_ctx, artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))),
-    )
-    asserts.equals(env, "project", project.label)
-
-def _fake_execute_for_cache_hit_test(args):
-    if args[0] == "cat":
-        if args[1] == "/tmp/blah/sha256/test/group/child-1.0.pom.sha256":
-            return struct(
-                return_code = 0,
-                stdout = "\n1234567812345678123456781234567812345678123456781234567812345678 \n",
-            )
-    fail("Unexpected Execution %s" % args)
-
-def get_pom_sha256_cache_hit_test(env):
-    fake_ctx = struct(
-        download = _noop_download,
-        read = _fake_execute_for_cache_hit_test,
-        attr = struct(
-            cache_poms_insecurely = True,
-            insecure_cache = "/tmp/blah",
-            pom_sha256_hashes = {},
-        ),
-        report_progress = _noop_report_progress,
-        execute = _fake_execute_for_cache_hit_test,
-    )
-    artifact = artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))
-    urls = ["fake://somerepo/test/group/child/1.0/child-1.0.pom"]
-    file = "test/group/child-1.0.pom"
-    sha256 = for_testing.get_pom_sha256(fake_ctx, artifact, urls, file)
-    asserts.equals(env, "1234567812345678123456781234567812345678123456781234567812345678", sha256)
-
-def _fake_download_for_cache_miss_test(url, output):
-    return struct(sha256 = "1234567812345678123456781234567812345678123456781234567812345678")
-
-def _fake_execute_for_cache_miss_test(args):
-    print(args)
-    if args[0] == "cat":
-        if args[1] == "/tmp/blah/sha256/test/group/child-1.0.pom.sha256":
-            return struct(return_code = 1)
-    elif args[0] == "bin/pom_hash_cache_write.sh":
-        if (args[1] == "1234567812345678123456781234567812345678123456781234567812345678" and
-            args[2] == "/tmp/blah/sha256/test/group/child-1.0.pom.sha256"):
-            return struct(return_code = 0)
-    fail("Unexpected Execution %s" % args)
-
-def get_pom_sha256_cache_miss_test(env):
-    fake_ctx = struct(
-        download = _fake_download_for_cache_miss_test,
-        read = _fake_read_for_get_pom_test,
-        attr = struct(
-            cache_poms_insecurely = True,
-            insecure_cache = "/tmp/blah",
-            pom_sha256_hashes = {},
-        ),
-        report_progress = _noop_report_progress,
-        execute = _fake_execute_for_cache_miss_test,
-    )
-    artifact = artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))
-    urls = ["fake://somerepo/test/group/child/1.0/child-1.0.pom"]
-    file = "test/group/child-1.0.pom"
-    sha256 = for_testing.get_pom_sha256(fake_ctx, artifact, urls, file)
-    asserts.equals(env, "1234567812345678123456781234567812345678123456781234567812345678", sha256)
-
-def get_pom_sha256_predefined_test(env):
-    fake_ctx = struct(
-        download = _fake_download_for_cache_miss_test,
-        read = _fake_read_for_get_pom_test,
-        attr = struct(
-            insecure_cache = "/tmp/blah",
-            pom_sha256_hashes = {
-                "test.group:child:1.0": "1234567812345678123456781234567812345678123456781234567812345678",
-            },
-        ),
-        report_progress = _noop_report_progress,
-    )
-    artifact = artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))
-    sha256 = for_testing.get_pom_sha256(fake_ctx, artifact, None, None)
-    asserts.equals(env, "1234567812345678123456781234567812345678123456781234567812345678", sha256)
-
-# Set up fakes.
-def _fake_read_for_get_parent_chain(path):
-    download_map = {
-        "test/group/parent-1.0.pom": PARENT_POM,
-        "test/grandparent-1.0.pom": GRANDPARENT_POM,
-    }
-    return download_map.get(path, "")
-
-def _extract_artifact_id(node):
-    for child_node in node.children:
-        if child_node.label == "artifactId":
-            return child_node.content
-
-def get_parent_chain_test(env):
-    fake_ctx = struct(
-        download = _noop_download,
-        read = _fake_read_for_get_parent_chain,
-        attr = struct(repository_urls = [_FAKE_URL_PREFIX], cache_poms_insecurely = False),
-        report_progress = _noop_report_progress,
-    )
-    chain = for_testing.get_inheritance_chain(fake_ctx, COMPLEX_POM)
-    asserts.equals(env, ["child", "parent", "grandparent"], [_extract_artifact_id(x) for x in chain])
-
-def get_effective_pom_test(env):
-    inheritance_chain = [poms.parse(COMPLEX_POM), poms.parse(PARENT_POM), poms.parse(GRANDPARENT_POM)]
-
-    merged = for_testing.get_effective_pom(inheritance_chain)
-
-    asserts.equals(env, "test.group", xml.find_first(merged, "groupId").content, "groupId")
-    asserts.equals(env, "child", xml.find_first(merged, "artifactId").content, "artifactId")
-    asserts.equals(env, "1.0", xml.find_first(merged, "version").content, "version")
-    asserts.equals(env, "jar", xml.find_first(merged, "packaging").content, "packaging")
+def _pass_through_path(label):
+    return label.name
 
 def get_dependencies_from_project_test(env):
     fake_ctx = struct(
         download = _noop_download,
-        read = _fake_read_for_get_parent_chain,
+        execute = _fake_read_for_get_parent_chain,
         attr = struct(repository_urls = [_FAKE_URL_PREFIX], cache_poms_insecurely = False),
         report_progress = _noop_report_progress,
+        path = _pass_through_path,
     )
-    project = for_testing.get_effective_pom(for_testing.get_inheritance_chain(fake_ctx, COMPLEX_POM))
+    artifact = artifacts.parse_spec("test.group:child:1.0")
+    project = poms_testing.merge_inheritance_chain(poms_testing.get_inheritance_chain(fake_ctx, artifact))
 
     # confirm junit is present.  This is just a precondition assertion, testing the baseline deps mechanism
     dependencies = [d.coordinate for d in for_testing.get_dependencies_from_project(fake_ctx, [], project)]
@@ -184,20 +71,13 @@ def get_dependencies_from_project_test(env):
     dependencies = [d.coordinate for d in for_testing.get_dependencies_from_project(fake_ctx, ["junit:junit"], project)]
     asserts.false(env, sets.contains(sets.copy_of(dependencies), "junit:junit"), "Should NOT contain junit:junit")
 
+TESTS = [
+    unsupported_keys_test,
+    handle_legacy_sha_handling,
+    handle_legacy_build_snippet_handling,
+    get_dependencies_from_project_test,
+]
+
 # Roll-up function.
 def suite():
-    return test_suite(
-        "maven processing",
-        tests = [
-            unsupported_keys_test,
-            handle_legacy_sha_handling,
-            handle_legacy_build_snippet_handling,
-            get_pom_test,
-            get_pom_sha256_cache_hit_test,
-            get_pom_sha256_cache_miss_test,
-            get_pom_sha256_predefined_test,
-            get_parent_chain_test,
-            get_effective_pom_test,
-            get_dependencies_from_project_test,
-        ],
-    )
+    return test_suite("maven processing", tests = TESTS)

--- a/maven/tests/poms_for_testing.bzl
+++ b/maven/tests/poms_for_testing.bzl
@@ -50,6 +50,14 @@ SIMPLE_PROPERTIES_POM = POM_PREFIX + """
   </properties>
 """ + POM_SUFFIX
 
+SIMPLE_PACKAGING_AAR_POM = POM_PREFIX + """
+  <packaging>aar</packaging>
+""" + POM_SUFFIX
+
+SIMPLE_PACKAGING_BUNDLE_POM = POM_PREFIX + """
+  <packaging>bundle</packaging>
+""" + POM_SUFFIX
+
 GRANDPARENT_POM = POM_PREFIX + """
   <modelVersion>4.0.0</modelVersion>
   <groupId>test</groupId>

--- a/maven/tests/poms_test.bzl
+++ b/maven/tests/poms_test.bzl
@@ -5,11 +5,15 @@ load(
     "PARENT_POM",
     "SCOPED_DEP_POM",
     "SIMPLE_DEP_POM",
+    "SIMPLE_PACKAGING_AAR_POM",
+    "SIMPLE_PACKAGING_BUNDLE_POM",
     "SIMPLE_PROPERTIES_POM",
     "SYSTEM_PATH_POM",
 )
 load(":testing.bzl", "asserts", "test_suite")
+load("//maven:artifacts.bzl", "artifacts")
 load("//maven:poms.bzl", "for_testing", "poms")
+load("//maven:xml.bzl", "xml")
 
 def simple_pom_fragment_process(env):
     deps = poms.extract_dependencies(poms.parse(SIMPLE_DEP_POM))
@@ -62,6 +66,12 @@ def complex_pom_test(env):
     asserts.true(env, managed_dependencies)
     asserts.equals(env, 1, len(managed_dependencies), "managed_dependencies")
 
+def extract_packaging_test(env):
+    asserts.equals(env, "pom", poms.extract_packaging(poms.parse(PARENT_POM)))
+    asserts.equals(env, "jar", poms.extract_packaging(poms.parse(COMPLEX_POM)))
+    asserts.equals(env, "aar", poms.extract_packaging(poms.parse(SIMPLE_PACKAGING_AAR_POM)))
+    asserts.equals(env, "bundle", poms.extract_packaging(poms.parse(SIMPLE_PACKAGING_BUNDLE_POM)))
+
 def extract_parent_test(env):
     pom = poms.parse(COMPLEX_POM)
     parent_artifact = poms.extract_parent(pom)
@@ -71,7 +81,7 @@ def extract_parent_test(env):
     asserts.equals(env, "grandparent", parent_artifact.artifact_id)
     pom = poms.parse(GRANDPARENT_POM)
     parent_artifact = poms.extract_parent(pom)
-    asserts.false(env, parent_artifact)
+    asserts.false(env, bool(parent_artifact))
 
 def extract_properties_simple_test(env):
     properties = poms.extract_properties(poms.parse(SIMPLE_PROPERTIES_POM))
@@ -127,17 +137,48 @@ def boolean_options_whitespace_test(env):
     asserts.false(env, dependencies[0].optional, "optional should be false for foo")
     asserts.true(env, dependencies[1].optional, "optional should be true for bar")
 
+def merge_inheritance_chain_test(env):
+    inheritance_chain = [poms.parse(COMPLEX_POM), poms.parse(PARENT_POM), poms.parse(GRANDPARENT_POM)]
+
+    merged = for_testing.merge_inheritance_chain(inheritance_chain)
+
+    asserts.equals(env, "test.group", xml.find_first(merged, "groupId").content, "groupId")
+    asserts.equals(env, "child", xml.find_first(merged, "artifactId").content, "artifactId")
+    asserts.equals(env, "1.0", xml.find_first(merged, "version").content, "version")
+    asserts.equals(env, "jar", xml.find_first(merged, "packaging").content, "packaging")
+
+# Set up fakes.
+def _fake_execute(args):
+    download_map = {
+        "test/group/child/1.0/child-1.0.pom": struct(return_code = 0, stdout = COMPLEX_POM),
+        "test/group/parent/1.0/parent-1.0.pom": struct(return_code = 0, stdout = PARENT_POM),
+        "test/grandparent/1.0/grandparent-1.0.pom": struct(return_code = 0, stdout = GRANDPARENT_POM),
+    }
+    return download_map.get(args[1], struct(return_code = 5, stderr = "ERROR!!!!!"))
+
+def _pass_through_path(label):
+    return label.name
+
+def get_parent_chain_test(env):
+    fake_ctx = struct(path = _pass_through_path, execute = _fake_execute)
+    chain = for_testing.get_inheritance_chain(fake_ctx, artifacts.parse_spec("test.group:child:1.0"))
+    actual_ids = [poms.extract_artifact_id(x) for x in chain]
+    asserts.equals(env, ["child", "parent", "grandparent"], actual_ids)
+
 TESTS = [
     simple_pom_fragment_process,
     simple_pom_fragment_process_scope,
     simple_pom_fragment_process_system_path,
     complex_pom_test,
     extract_parent_test,
+    extract_packaging_test,
     extract_properties_simple_test,
     extract_properties_complex_pom_test,
     get_variable_test,
     substitute_variable_test,
     boolean_options_whitespace_test,
+    merge_inheritance_chain_test,
+    get_parent_chain_test,
 ]
 
 # Roll-up function.

--- a/maven/tests/poms_test.bzl
+++ b/maven/tests/poms_test.bzl
@@ -159,8 +159,11 @@ def _fake_execute(args):
 def _pass_through_path(label):
     return label.name
 
+def _noop_report(string):
+    pass
+
 def get_parent_chain_test(env):
-    fake_ctx = struct(path = _pass_through_path, execute = _fake_execute)
+    fake_ctx = struct(path = _pass_through_path, execute = _fake_execute, report_progress = _noop_report)
     chain = for_testing.get_inheritance_chain(fake_ctx, artifacts.parse_spec("test.group:child:1.0"))
     actual_ids = [poms.extract_artifact_id(x) for x in chain]
     asserts.equals(env, ["child", "parent", "grandparent"], actual_ids)

--- a/maven/utils.bzl
+++ b/maven/utils.bzl
@@ -13,9 +13,13 @@ def _trim(string, characters = "\n "):
 def _contains(string, substring):
     return not (string.find(substring) == -1)
 
+def _munge(artifact_id):
+    return artifact_id.replace("-", "_").replace(".", "_")
+
 strings = struct(
     contains = _contains,
     trim = _trim,
+    munge = _munge,
 )
 
 def _filename(string):

--- a/maven/xml.bzl
+++ b/maven/xml.bzl
@@ -205,7 +205,7 @@ def _new_node(label, content = None, children = []):
     return struct(label = label, content = content, children = children)
 
 # Description:
-#   Returns the first node with the given label, if it's present in the children of the given node.
+#   Returns the first node with one of the given labels, if it's present in the children of the given node.
 def _find_first(node, *labels):
     stack = []
     current = node

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -102,12 +102,12 @@ maven_repository_specification(
         "org.checkerframework:checker-qual:2.5.3": {"insecure": True},
         "com.googlecode.java-diff-utils:diffutils:1.3.0": {"insecure": True},
         "com.google.auto.value:auto-value-annotations:1.6.3": {"insecure": True},
-        "com.google.auto.value:auto-value:1.6.3": { "insecure": True, "build_snippet": AUTO_VALUE_BUILD_SNIPPET_WITH_PLUGIN.format(version = "1.6.3"), },
-        "org.reflections:reflections:0.9.11": { "insecure": True }, # test leniency related to #62.
+        "com.google.auto.value:auto-value:1.6.3": {"insecure": True, "build_snippet": AUTO_VALUE_BUILD_SNIPPET_WITH_PLUGIN.format(version = "1.6.3")},
+        "org.reflections:reflections:0.9.11": {"insecure": True }, # test leniency related to #62.
         "org.javassist:javassist:3.21.0-GA": {"insecure": True}, # Only needed if #62 is fixed.
-        "androidx.arch.core:core-runtime:2.0.1:aar": {"insecure": True},
+        "androidx.arch.core:core-runtime:2.0.0": {"insecure": True},
         "androidx.annotation:annotation:1.0.2": {"insecure": True},
-        "androidx.arch.core:core-common:2.0.1": {"insecure": True},
+        "androidx.arch.core:core-common:2.0.0": {"insecure": True},
     },
     repository_urls = [
         "https://repo1.maven.org/maven2",


### PR DESCRIPTION
Discovers the pom packaging type from the pom.xml as-parsed, avoiding the need to specify it in the artifact dictionary (unless a classifier is being used, in which case it must precede the classifier, as that's the standard format of the maven slug).

Also factor out an faux-enum, add testing of the packaging detection, rework pom fetching into individual external workspaces, move common naming into shared functions in globals.bzl, add an android use-case, etc.

This PR also adds a bit more report_progress granularity, in the hopes of having more exposure of the timings of things.

More detail:

The design splits pom handling into two phases.  The first is the fetch itself, which partially parses the pom enough to get the inheritance hierarchy, in order to know what to fetch next.  Then separately, the parse-and-merge (and use the metadata) is in a separate step, which relies on the first having happened.  In this second phase, the poms are "fetched" from the file system, from the target locations of the download rules.

The locations are defined deterministically based on the artifact coordinates, and those assumptions are coded into the globals.bzl functions, which provide canonical locations in the build whereby those pom files can be obtained. This provides a de-facto contract between the pom fetching rule and the pom processing / build file assembly rule. 

Fixes #59 