### PR TITLE
Relax name mangling of artifact_ids

### DIFF
--- a/maven/artifacts.bzl
+++ b/maven/artifacts.bzl
@@ -35,7 +35,6 @@ def _parse_spec(artifact_spec):
         version = version,
     )
 
-
 # Builds an annotated struct from a more basic artifact struct, with standard paths, names, and other values
 # derived from the basic artifact spec elements.
 def _annotate_artifact(artifact):
@@ -67,7 +66,6 @@ def _annotate_artifact(artifact):
     ) if bool(artifact.version) else None
 
     annotated_artifact = struct(
-        third_party_target_name = strings.munge(artifact.artifact_id),
         path = path,
         group_path = group_path,
         pom = pom,

--- a/maven/globals.bzl
+++ b/maven/globals.bzl
@@ -15,7 +15,7 @@ def _group_path(artifact):
 def _artifact_repo_name(artifact):
     # Extra empty strings are there to force "__" in between sections (to disambiguate
     # "foo:bar-parent:1.0" from "foo.bar:parent:1.0" in fetch repos.
-    artifact_id_munged = strings.munge(artifact.artifact_id)
+    artifact_id_munged = strings.munge(artifact.artifact_id, ".", "-")
     munged_classifier_if_present = [strings.munge(artifact.classifier.split)] if artifact.classifier else []
     group_elements = artifact.group_id.split(".")
     return "_".join([_REPO_PREFIX, ""] + group_elements + ["", artifact_id_munged] + munged_classifier_if_present)

--- a/maven/tests/all_tests.bzl
+++ b/maven/tests/all_tests.bzl
@@ -11,8 +11,8 @@ load(":xml_test.bzl", xml = "suite")
 
 load("//maven:sets.bzl", "sets")
 
-
-SUITES = [dicts, fetch, globals, paths, maven, poms, poms_merging, set_tests, strings, xml]
+# Order by more fundamental/generic, so we can see those errors earlier.
+SUITES = [dicts, set_tests, strings, globals, xml, fetch, paths, poms, poms_merging, maven]
 
 def _validate(ctx, suites):
     # Function objects don't have good properties, so we hack it from the string representation.

--- a/maven/tests/strings_test.bzl
+++ b/maven/tests/strings_test.bzl
@@ -11,6 +11,13 @@ def contains_test(env):
     asserts.true(env, strings.contains("foobarbash", "bar"))
     asserts.false(env, strings.contains("foobarbash", "Bar"))
 
+def munge_test(env):
+    asserts.equals(env, "foo", strings.munge("foo", ".", "-"))
+    asserts.equals(env, "f_o-o", strings.munge("f.o-o", "."))
+    asserts.equals(env, "f.o_o", strings.munge("f.o-o", "-"))
+    asserts.equals(env, "f_o_o", strings.munge("f.o-o", ".", "-"))
+    asserts.equals(env, "f_o_o", strings.munge("f.o-o", "-", "."))
+
 # Roll-up function.
 def suite():
-    return test_suite("strings", tests = [trim_test_custom, trim_test_default, contains_test])
+    return test_suite("strings", tests = [trim_test_custom, trim_test_default, contains_test, munge_test])

--- a/maven/utils.bzl
+++ b/maven/utils.bzl
@@ -13,8 +13,12 @@ def _trim(string, characters = "\n "):
 def _contains(string, substring):
     return not (string.find(substring) == -1)
 
-def _munge(artifact_id):
-    return artifact_id.replace("-", "_").replace(".", "_")
+def _munge(string, *characters_to_munge):
+    if len(characters_to_munge) == 0:
+        fail("Illegal argument: characters_to_munge must not be empty")
+    for char in characters_to_munge:
+        string = string.replace(char, "_")
+    return string
 
 strings = struct(
     contains = _contains,
@@ -27,14 +31,14 @@ def _filename(string):
     return file if bool(sep) else string
 
 paths = struct(
-    filename = _filename
+    filename = _filename,
 )
 
 def _max_int(a, b):
     return a if a > b else b
 
 ints = struct(
-    max = _max_int
+    max = _max_int,
 )
 
 # Encodes a dict(string->dict(string->string)) into a dict(string->list(string)) with the string encoded so it can

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -49,7 +49,10 @@ maven_repository_specification(
     # If supplied, this will be the alternate location for insecure sha hashes.
     #
     # This can be an absolute or a path relative to ${HOME}
-    insecure_cache=".cache/bazel_maven_repository", # This is the default
+    insecure_cache = ".cache/bazel_maven_repository", # This is the default
+
+    # Enable the creation of older-style mangling where foo-bar becomes foo_bar (for migration)
+    legacy_artifact_id_munge = True,
 
     # The artifact spec list.
     artifacts = {
@@ -120,7 +123,7 @@ maven_repository_specification(
         # annotation processor) we need to rewrite the internal dependencies inside the com/google/dagger package
         # to reflect this.
         # "groupId": { "full bazel target": "full alternate target" }
-        "com.google.dagger": {"@maven//com/google/dagger:dagger": "@maven//com/google/dagger:dagger_api"},
+        "com.google.dagger": {"@maven//com/google/dagger:dagger": "@maven//com/google/dagger:dagger-api"},
     },
 )
 

--- a/test/test_workspace/build_substitution_templates.bzl
+++ b/test/test_workspace/build_substitution_templates.bzl
@@ -14,24 +14,25 @@
 DAGGER_BUILD_SNIPPET_WITH_PLUGIN = """
 java_library(
    name = "dagger",
-   exports = [":dagger_api"],
-   exported_plugins = [":dagger_plugin"],
+   exports = [":dagger-api"],
+   exported_plugins = [":dagger-plugin"],
    visibility = ["//visibility:public"],
 )
 
 maven_jvm_artifact(
-   name = "dagger_api",
+   name = "dagger-api",
    exports = [
+       # Must use javax_inject instead of javax.inject
        "@maven//javax/inject:javax_inject",
    ],
    artifact = "com.google.dagger:dagger:{version}",
 )
 
 java_plugin(
-   name = "dagger_plugin",
+   name = "dagger-plugin",
    processor_class = "dagger.internal.codegen.ComponentProcessor",
    generates_api = True,
-   deps = [":dagger_compiler"],
+   deps = [":dagger-compiler"],
 )
 """
 
@@ -45,13 +46,13 @@ java_plugin(
 AUTO_VALUE_BUILD_SNIPPET_WITH_PLUGIN = """
 java_library(
    name = "value",
-   exports = [":auto_value_annotations"],
+   exports = [":auto-value-annotations"],
    exported_plugins = [":plugin"],
    visibility = ["//visibility:public"],
 )
 
 maven_jvm_artifact(
-   name = "auto_value_processor",
+   name = "auto-value-processor",
    artifact = "com.google.auto.value:auto-value:{version}",
 )
 
@@ -59,6 +60,6 @@ java_plugin(
    name = "plugin",
    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
    generates_api = True,
-   deps = [":auto_value_processor"],
+   deps = [":auto-value-processor"],
 )
 """

--- a/test/test_workspace/java/blah/BUILD.bazel
+++ b/test/test_workspace/java/blah/BUILD.bazel
@@ -2,9 +2,10 @@ package(default_visibility = ["//:__subpackages__"])
 
 android_library(
     name = "blah",
-    manifest = "AndroidManifest.xml",
     srcs = ["Blah.java"],
+    manifest = "AndroidManifest.xml",
     deps = [
-        "@maven//androidx/arch/core:core_runtime",
-    ]
+        "@maven//androidx/arch/core:core_runtime",  # Use the legacy mangling alias.
+        "@maven//javax/annotation:jsr250-api",
+    ],
 )


### PR DESCRIPTION
Relax some of the name mangling that bazel_maven_repository does, so that artifact_ids that don't have `.` in their names aren't mangled.

In particular, `-` is now not mangled, as a lot of artifact_ids have this, but bazel is perfectly capable of handling this when it comes to targets.

The upshot is that now `com.google.dagger:dagger-compiler:2.24` would be referenced as `@maven//com/google/dagger:dagger-compiler`

Also add a legacy mode, so that projects upgrading can just flag on to have compatibility aliases generated with the old names, while they adjust to the new naming implications.  In the above case, it would result in the following snippet being added to `external/maven/com/google/dagger/BUILD.bazel`:

```
alias(
    name = "dagger_compiler",
    actual = ":dagger-compiler",
    visibility = ["//visibility:public"],
)
```

The legacy target is obviously not generated if the old and new mangling methods would have the same result.
