### PR TITLE
Convert to using read() (a 0.29+ api).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,8 @@ env:
     - BAZELISK_VERSION="0.0.8"
     - PATH=${PATH}:${ANDROID_HOME}/tools/bin:${HOME}/bin
   matrix:
-    - USE_BAZEL_VERSION="0.26.1" SEGMENT="."
-    - USE_BAZEL_VERSION="0.26.1" SEGMENT="test/test_workspace"
-    - USE_BAZEL_VERSION="0.27.0" SEGMENT="."
-    - USE_BAZEL_VERSION="0.27.0" SEGMENT="test/test_workspace"
-    - USE_BAZEL_VERSION="0.27.1" SEGMENT="."
-    - USE_BAZEL_VERSION="0.27.1" SEGMENT="test/test_workspace"
-    - USE_BAZEL_VERSION="0.27.2" SEGMENT="."
-    - USE_BAZEL_VERSION="0.27.2" SEGMENT="test/test_workspace"
-    - USE_BAZEL_VERSION="0.28.0" SEGMENT="."
-    - USE_BAZEL_VERSION="0.28.0" SEGMENT="test/test_workspace"
+    - USE_BAZEL_VERSION="0.29.0" SEGMENT="."
+    - USE_BAZEL_VERSION="0.29.0" SEGMENT="test/test_workspace"
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -462,10 +462,11 @@ effort testing)?
 | Bazel 0.22.x | ![Yes] | ![No] |
 | Bazel 0.23.x | ![Yes] | ![No] |
 | Bazel 0.24.x | ![Yes] | ![No] |
-| Bazel 0.25.x | ![Yes] | ![Yes] |
-| Bazel 0.26.x | ![Yes] | ![Yes] |
-| Bazel 0.27.x | ![Yes] | ![Yes] |
-| Bazel 0.28.0 | ![Yes] | ![Yes] |
+| Bazel 0.25.x | ![Yes] | ![No] |
+| Bazel 0.26.x | ![Yes] | ![No] |
+| Bazel 0.27.x | ![Yes] | ![No] |
+| Bazel 0.28.0 | ![Yes] | ![No] |
+| Bazel 0.29.0 | ![Yes] | ![Yes] |
 
 [Yes]: https://img.shields.io/static/v1.svg?label=&message=Yes&color=green
 [No]: https://img.shields.io/static/v1.svg?label=&message=No&color=red

--- a/maven/artifacts.bzl
+++ b/maven/artifacts.bzl
@@ -1,5 +1,5 @@
 #
-# Utilities for processing maven artifact coordinates and generating useful structs.
+# Utilities for processing maven artifact specs and generating useful structs.
 #
 load(":utils.bzl", "strings")
 
@@ -33,52 +33,9 @@ def _parse_spec(artifact_spec):
         type = type,
         classifier = classifier,
         version = version,
+        coordinates = "%s:%s" % (group_id, artifact_id) # versionless coordinates
     )
-
-# Builds an annotated struct from a more basic artifact struct, with standard paths, names, and other values
-# derived from the basic artifact spec elements.
-def _annotate_artifact(artifact):
-    if not bool(artifact.version):
-        fail("Error, no version specified for %s:%s" % (artifact.group_id, artifact.artifact_id))
-
-    # assemble paths and target names and such.
-    suffix = artifact.type
-    group_path = "/".join(artifact.group_id.split("."))
-    if bool(artifact.classifier):
-        path = None if not bool(artifact.version) else _artifact_template_with_classifier.format(
-            group_path = group_path,
-            artifact_id = artifact.artifact_id,
-            version = artifact.version,
-            suffix = suffix,
-            classifier = artifact.classifier,
-        )
-    else:
-        path = None if not bool(artifact.version) else _artifact_template.format(
-            group_path = group_path,
-            artifact_id = artifact.artifact_id,
-            version = artifact.version,
-            suffix = suffix,
-        )
-    pom = _artifact_pom_template.format(
-        group_path = group_path,
-        artifact_id = artifact.artifact_id,
-        version = artifact.version,
-    ) if bool(artifact.version) else None
-
-    annotated_artifact = struct(
-        path = path,
-        group_path = group_path,
-        pom = pom,
-        original_spec = artifact.original_spec,
-        group_id = artifact.group_id,
-        artifact_id = artifact.artifact_id,
-        type = artifact.type,
-        classifier = artifact.classifier,
-        version = artifact.version,
-    )
-    return annotated_artifact
 
 artifacts = struct(
     parse_spec = _parse_spec,
-    annotate = _annotate_artifact,
 )

--- a/maven/fetch.bzl
+++ b/maven/fetch.bzl
@@ -38,14 +38,7 @@ def _format_exported_files(paths):
 def _get_packaging_type(ctx, pom_label):
     packaging_type_file = pom_label.relative(":%s" % PACKAGING_TYPE_FILE)
     path = ctx.path(packaging_type_file)
-    result = ctx.execute(["cat", path])  # TODO(cgruber) Convert to read post Bazel 0.29
-    if result.return_code != 0:
-        fail("Failed to retreive packaging type from %s for artifact %s: %s" % (
-            packaging_type_file,
-            ctx.attr.artifact,
-            result.stderr,
-        ))
-    return strings.trim(result.stdout)
+    return strings.trim(ctx.read(path))
 
 # Downloads an artifact and exports it into the build language.
 def _fetch_artifact_impl(ctx):
@@ -93,9 +86,9 @@ def _get_pom_sha256(ctx, artifact, urls, file):
         cache_dir = "%s/%s" % (ctx.attr.insecure_cache, _POM_HASH_INFIX)
     else:
         cache_dir = "%s/%s/%s" % (ctx.os.environ["HOME"], ctx.attr.insecure_cache, _POM_HASH_INFIX)
-    cached_file = "%s/%s.sha256" % (cache_dir, file)
-    sha_cache_result = ctx.execute(["cat", cached_file])  # TODO(cgruber) Convert to read post Bazel 0.29
-    if sha_cache_result.return_code != 0:
+    cached_file = ctx.path("%s/%s.sha256" % (cache_dir, file))
+
+    if not ctx.path(cached_file).exists:
         # This will result in a CA cache miss and an extra download on first use, since the first
         # (non-sha-attributed) download won't store anything in the CA cache.
         ctx.report_progress("%s not locally cached, fetching and hashing" % cached_file)
@@ -105,7 +98,7 @@ def _get_pom_sha256(ctx, artifact, urls, file):
             fail("Cache write failed with code %s, stderr: %s", (result.return_code, result.stderr))
         return pom_result.sha256
     else:
-        return strings.trim(sha_cache_result.stdout)
+        return strings.trim(ctx.read(cached_file))
 
 # Fetch the pom for the artifact.  First see if a cached hash is available for it. If so, use
 # that hash to try a download with the sha, to get a hit on the content addressable cache. If not

--- a/maven/fetch.bzl
+++ b/maven/fetch.bzl
@@ -88,7 +88,7 @@ def _get_pom_sha256(ctx, artifact, urls, file):
         cache_dir = "%s/%s/%s" % (ctx.os.environ["HOME"], ctx.attr.insecure_cache, _POM_HASH_INFIX)
     cached_file = ctx.path("%s/%s.sha256" % (cache_dir, file))
 
-    if not ctx.path(cached_file).exists:
+    if not cached_file.exists:
         # This will result in a CA cache miss and an extra download on first use, since the first
         # (non-sha-attributed) download won't store anything in the CA cache.
         ctx.report_progress("%s not locally cached, fetching and hashing" % cached_file)

--- a/maven/globals.bzl
+++ b/maven/globals.bzl
@@ -16,7 +16,7 @@ def _artifact_repo_name(artifact):
     # Extra empty strings are there to force "__" in between sections (to disambiguate
     # "foo:bar-parent:1.0" from "foo.bar:parent:1.0" in fetch repos.
     artifact_id_munged = strings.munge(artifact.artifact_id, ".", "-")
-    munged_classifier_if_present = [strings.munge(artifact.classifier.split)] if artifact.classifier else []
+    munged_classifier_if_present = [strings.munge(artifact.classifier, ".", "-")] if artifact.classifier else []
     group_elements = artifact.group_id.split(".")
     return "_".join([_REPO_PREFIX, ""] + group_elements + ["", artifact_id_munged] + munged_classifier_if_present)
 

--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -86,7 +86,7 @@ def _dependency(
         scope = scope,
         classifier = classifier,
         system_path = system_path,
-        coordinate = "%s:%s" % (group_id, artifact_id),
+        coordinates = "%s:%s" % (group_id, artifact_id),
     )
 
 # A set of property defaults for dependencies, to be merged at the last minute.  Omits the groupId
@@ -163,11 +163,11 @@ def _get_processed_dependencies(project_node):
     result = []
     dependency_management = {}
     for dep in _extract_dependency_management(project_node):
-        dependency_management[dep.coordinate] = dep
+        dependency_management[dep.coordinates] = dep
     dependencies = _extract_dependencies(project_node)
     properties = _extract_properties(project_node)
     for dep in dependencies:
-        dep = _merge_dependency(dependency_management.get(dep.coordinate, None), dep)
+        dep = _merge_dependency(dependency_management.get(dep.coordinates, None), dep)
         dep = _apply_property(dep, properties)
         dep = _merge_dependency(_DEPENDENCY_DEFAULT, dep)  # fill in any needed default values.
         result.append(dep)

--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -389,15 +389,7 @@ def _merge_parent(parent, child):
     ]))
     return merged
 
-# A function to read the pom from the place it was downloaded to.  This should be a lambda in any reasonable language.
-def _read_pom(ctx, path):
-    result = ctx.execute(["cat", path])
-    if result.return_code != 0:
-        fail("Failed to read pom file from %s: %s" % (path, result.return_code))
-    return result.stdout
 
-def _trace_parse(ctx, xml_text):
-    ctx.repo
 # Builds a chain of nodes representing pom xml data in a hierarchical inheritance relationship which
 # can be collapsed or wrapped.
 def _get_inheritance_chain(ctx, artifact):
@@ -409,7 +401,7 @@ def _get_inheritance_chain(ctx, artifact):
             return inheritance_chain
         path = ctx.path(fetch_repo.pom_target_relative_to(current, fetch_repo.pom_repo_name(artifact)))
         ctx.report_progress("Reading pom for %s" % current.original_spec)
-        xml_text = _read_pom(ctx, path)
+        xml_text = ctx.read(path)
         ctx.report_progress("Parsing pom for %s" % current.original_spec)
         current_node = _parse(xml_text)
         inheritance_chain += [current_node]

--- a/maven/tests/maven_test.bzl
+++ b/maven/tests/maven_test.bzl
@@ -64,11 +64,11 @@ def get_dependencies_from_project_test(env):
     project = poms_testing.merge_inheritance_chain(poms_testing.get_inheritance_chain(fake_ctx, artifact))
 
     # confirm junit is present.  This is just a precondition assertion, testing the baseline deps mechanism
-    dependencies = [d.coordinate for d in for_testing.get_dependencies_from_project(fake_ctx, [], project)]
+    dependencies = [d.coordinates for d in for_testing.get_dependencies_from_project(fake_ctx, [], project)]
     asserts.true(env, sets.contains(sets.copy_of(dependencies), "junit:junit"), "Should contain junit:junit")
 
     # confirm junit is excluded
-    dependencies = [d.coordinate for d in for_testing.get_dependencies_from_project(fake_ctx, ["junit:junit"], project)]
+    dependencies = [d.coordinates for d in for_testing.get_dependencies_from_project(fake_ctx, ["junit:junit"], project)]
     asserts.false(env, sets.contains(sets.copy_of(dependencies), "junit:junit"), "Should NOT contain junit:junit")
 
 TESTS = [

--- a/maven/tests/maven_test.bzl
+++ b/maven/tests/maven_test.bzl
@@ -35,13 +35,13 @@ def handle_legacy_build_snippet_handling(env):
     )
 
 # Set up fakes.
-def _fake_read_for_get_parent_chain(args):
+def _fake_read_for_get_parent_chain(path):
     download_map = {
-        "test/group/child/1.0/child-1.0.pom": struct(return_code = 0, stdout = COMPLEX_POM),
-        "test/group/parent/1.0/parent-1.0.pom": struct(return_code = 0, stdout = PARENT_POM),
-        "test/grandparent/1.0/grandparent-1.0.pom": struct(return_code = 0, stdout = GRANDPARENT_POM),
+        "test/group/child/1.0/child-1.0.pom": COMPLEX_POM,
+        "test/group/parent/1.0/parent-1.0.pom": PARENT_POM,
+        "test/grandparent/1.0/grandparent-1.0.pom": GRANDPARENT_POM,
     }
-    return download_map.get(args[1], struct(return_code = 5, stderr = "ERROR!!!!!"))
+    return download_map.get(path, None)
 
 def _noop_download(url, output):
     pass
@@ -55,7 +55,7 @@ def _pass_through_path(label):
 def get_dependencies_from_project_test(env):
     fake_ctx = struct(
         download = _noop_download,
-        execute = _fake_read_for_get_parent_chain,
+        read = _fake_read_for_get_parent_chain,
         attr = struct(repository_urls = [_FAKE_URL_PREFIX], cache_poms_insecurely = False),
         report_progress = _noop_report_progress,
         path = _pass_through_path,

--- a/maven/tests/poms_merging_test.bzl
+++ b/maven/tests/poms_merging_test.bzl
@@ -114,7 +114,7 @@ def inferred_values_in_dependencies_test(env):
     dependencies = poms.extract_dependencies(poms.parse(MERGED_EXPECTED_POM))
     indexed_dependencies = {}
     for dep in dependencies:
-        indexed_dependencies[dep.coordinate] = dep
+        indexed_dependencies[dep.coordinates] = dep
     asserts.equals(env, 5, len(dependencies), "number of dependencies")
     asserts.true(env, indexed_dependencies.get("com.google.code.findbugs:jsr305", None), "has jsr305")
     asserts.equals(

--- a/maven/tests/poms_test.bzl
+++ b/maven/tests/poms_test.bzl
@@ -148,13 +148,13 @@ def merge_inheritance_chain_test(env):
     asserts.equals(env, "jar", xml.find_first(merged, "packaging").content, "packaging")
 
 # Set up fakes.
-def _fake_execute(args):
+def _fake_read(path):
     download_map = {
-        "test/group/child/1.0/child-1.0.pom": struct(return_code = 0, stdout = COMPLEX_POM),
-        "test/group/parent/1.0/parent-1.0.pom": struct(return_code = 0, stdout = PARENT_POM),
-        "test/grandparent/1.0/grandparent-1.0.pom": struct(return_code = 0, stdout = GRANDPARENT_POM),
+        "test/group/child/1.0/child-1.0.pom": COMPLEX_POM,
+        "test/group/parent/1.0/parent-1.0.pom": PARENT_POM,
+        "test/grandparent/1.0/grandparent-1.0.pom": GRANDPARENT_POM,
     }
-    return download_map.get(args[1], struct(return_code = 5, stderr = "ERROR!!!!!"))
+    return download_map.get(path, None)
 
 def _pass_through_path(label):
     return label.name
@@ -163,7 +163,7 @@ def _noop_report(string):
     pass
 
 def get_parent_chain_test(env):
-    fake_ctx = struct(path = _pass_through_path, execute = _fake_execute, report_progress = _noop_report)
+    fake_ctx = struct(path = _pass_through_path, read = _fake_read, report_progress = _noop_report)
     chain = for_testing.get_inheritance_chain(fake_ctx, artifacts.parse_spec("test.group:child:1.0"))
     actual_ids = [poms.extract_artifact_id(x) for x in chain]
     asserts.equals(env, ["child", "parent", "grandparent"], actual_ids)

--- a/maven/utils.bzl
+++ b/maven/utils.bzl
@@ -13,12 +13,12 @@ def _trim(string, characters = "\n "):
 def _contains(string, substring):
     return not (string.find(substring) == -1)
 
-def _munge(string, *characters_to_munge):
+def _munge(to_mangle, *characters_to_munge):
     if len(characters_to_munge) == 0:
-        fail("Illegal argument: characters_to_munge must not be empty")
+        fail("Illegal argument: no mangling characters given when mangling %s" % to_mangle)
     for char in characters_to_munge:
-        string = string.replace(char, "_")
-    return string
+        to_mangle = to_mangle.replace(char, "_")
+    return to_mangle
 
 strings = struct(
     contains = _contains,


### PR DESCRIPTION
Also clean up from prior refactorings, notably removing all the annotate() calls which are now superfluous.