### PR TITLE
Add support for AndroidX

### DIFF
--- a/maven/jetifier.bzl
+++ b/maven/jetifier.bzl
@@ -1,0 +1,170 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
+
+# Based on https://developer.android.com/jetpack/androidx/migrate/artifact-mappings
+JETIFIER_ARTIFACT_MAPPING = {
+    'android.arch.core:common': 'androidx.arch.core:core-common',
+    'android.arch.core:core': 'androidx.arch.core:core',
+    'android.arch.core:core-testing': 'androidx.arch.core:core-testing',
+    'android.arch.core:runtime': 'androidx.arch.core:core-runtime',
+    'android.arch.lifecycle:common': 'androidx.lifecycle:lifecycle-common',
+    'android.arch.lifecycle:common-java8': 'androidx.lifecycle:lifecycle-common-java8',
+    'android.arch.lifecycle:compiler': 'androidx.lifecycle:lifecycle-compiler',
+    'android.arch.lifecycle:extensions': 'androidx.lifecycle:lifecycle-extensions',
+    'android.arch.lifecycle:livedata': 'androidx.lifecycle:lifecycle-livedata',
+    'android.arch.lifecycle:livedata-core': 'androidx.lifecycle:lifecycle-livedata-core',
+    'android.arch.lifecycle:reactivestreams': 'androidx.lifecycle:lifecycle-reactivestreams',
+    'android.arch.lifecycle:runtime': 'androidx.lifecycle:lifecycle-runtime',
+    'android.arch.lifecycle:viewmodel': 'androidx.lifecycle:lifecycle-viewmodel',
+    'android.arch.paging:common': 'androidx.paging:paging-common',
+    'android.arch.paging:runtime': 'androidx.paging:paging-runtime',
+    'android.arch.paging:rxjava2': 'androidx.paging:paging-rxjava2',
+    'android.arch.persistence.room:common': 'androidx.room:room-common',
+    'android.arch.persistence.room:compiler': 'androidx.room:room-compiler',
+    'android.arch.persistence.room:guava': 'androidx.room:room-guava',
+    'android.arch.persistence.room:migration': 'androidx.room:room-migration',
+    'android.arch.persistence.room:runtime': 'androidx.room:room-runtime',
+    'android.arch.persistence.room:rxjava2': 'androidx.room:room-rxjava2',
+    'android.arch.persistence.room:testing': 'androidx.room:room-testing',
+    'android.arch.persistence:db': 'androidx.sqlite:sqlite',
+    'android.arch.persistence:db-framework': 'androidx.sqlite:sqlite-framework',
+    'com.android.support.constraint:constraint-layout': 'androidx.constraintlayout:constraintlayout',
+    'com.android.support.constraint:constraint-layout-solver': 'androidx.constraintlayout:constraintlayout-solver',
+    'com.android.support.test.espresso.idling:idling-concurrent': 'androidx.test.espresso.idling:idling-concurrent',
+    'com.android.support.test.espresso.idling:idling-net': 'androidx.test.espresso.idling:idling-net',
+    'com.android.support.test.espresso:espresso-accessibility': 'androidx.test.espresso:espresso-accessibility',
+    'com.android.support.test.espresso:espresso-contrib': 'androidx.test.espresso:espresso-contrib',
+    'com.android.support.test.espresso:espresso-core': 'androidx.test.espresso:espresso-core',
+    'com.android.support.test.espresso:espresso-idling-resource': 'androidx.test.espresso:espresso-idling-resource',
+    'com.android.support.test.espresso:espresso-intents': 'androidx.test.espresso:espresso-intents',
+    'com.android.support.test.espresso:espresso-remote': 'androidx.test.espresso:espresso-remote',
+    'com.android.support.test.espresso:espresso-web': 'androidx.test.espresso:espresso-web',
+    'com.android.support.test.janktesthelper:janktesthelper': 'androidx.test.jank:janktesthelper',
+    'com.android.support.test.services:test-services': 'androidx.test:test-services',
+    'com.android.support.test.uiautomator:uiautomator': 'androidx.test.uiautomator:uiautomator',
+    'com.android.support.test:monitor': 'androidx.test:monitor',
+    'com.android.support.test:orchestrator': 'androidx.test:orchestrator',
+    'com.android.support.test:rules': 'androidx.test:rules',
+    'com.android.support.test:runner': 'androidx.test:runner',
+    'com.android.support:animated-vector-drawable': 'androidx.vectordrawable:vectordrawable-animated',
+    'com.android.support:appcompat-v7': 'androidx.appcompat:appcompat',
+    'com.android.support:asynclayoutinflater': 'androidx.asynclayoutinflater:asynclayoutinflater',
+    'com.android.support:car': 'androidx.car:car',
+    'com.android.support:cardview-v7': 'androidx.cardview:cardview',
+    'com.android.support:collections': 'androidx.collection:collection',
+    'com.android.support:coordinatorlayout': 'androidx.coordinatorlayout:coordinatorlayout',
+    'com.android.support:cursoradapter': 'androidx.cursoradapter:cursoradapter',
+    'com.android.support:customtabs': 'androidx.browser:browser',
+    'com.android.support:customview': 'androidx.customview:customview',
+    'com.android.support:design': 'com.google.android.material:material',
+    'com.android.support:documentfile': 'androidx.documentfile:documentfile',
+    'com.android.support:drawerlayout': 'androidx.drawerlayout:drawerlayout',
+    'com.android.support:exifinterface': 'androidx.exifinterface:exifinterface',
+    'com.android.support:gridlayout-v7': 'androidx.gridlayout:gridlayout',
+    'com.android.support:heifwriter': 'androidx.heifwriter:heifwriter',
+    'com.android.support:interpolator': 'androidx.interpolator:interpolator',
+    'com.android.support:leanback-v17': 'androidx.leanback:leanback',
+    'com.android.support:loader': 'androidx.loader:loader',
+    'com.android.support:localbroadcastmanager': 'androidx.localbroadcastmanager:localbroadcastmanager',
+    'com.android.support:media2': 'androidx.media2:media2',
+    'com.android.support:media2-exoplayer': 'androidx.media2:media2-exoplayer',
+    'com.android.support:mediarouter-v7': 'androidx.mediarouter:mediarouter',
+    'com.android.support:multidex': 'androidx.multidex:multidex',
+    'com.android.support:multidex-instrumentation': 'androidx.multidex:multidex-instrumentation',
+    'com.android.support:palette-v7': 'androidx.palette:palette',
+    'com.android.support:percent': 'androidx.percentlayout:percentlayout',
+    'com.android.support:preference-leanback-v17': 'androidx.leanback:leanback-preference',
+    'com.android.support:preference-v14': 'androidx.legacy:legacy-preference-v14',
+    'com.android.support:preference-v7': 'androidx.preference:preference',
+    'com.android.support:print': 'androidx.print:print',
+    'com.android.support:recommendation': 'androidx.recommendation:recommendation',
+    'com.android.support:recyclerview-selection': 'androidx.recyclerview:recyclerview-selection',
+    'com.android.support:recyclerview-v7': 'androidx.recyclerview:recyclerview',
+    'com.android.support:slices-builders': 'androidx.slice:slice-builders',
+    'com.android.support:slices-core': 'androidx.slice:slice-core',
+    'com.android.support:slices-view': 'androidx.slice:slice-view',
+    'com.android.support:slidingpanelayout': 'androidx.slidingpanelayout:slidingpanelayout',
+    'com.android.support:support-annotations': 'androidx.annotation:annotation',
+    'com.android.support:support-compat': 'androidx.core:core',
+    'com.android.support:support-content': 'androidx.contentpager:contentpager',
+    'com.android.support:support-core-ui': 'androidx.legacy:legacy-support-core-ui',
+    'com.android.support:support-core-utils': 'androidx.legacy:legacy-support-core-utils',
+    'com.android.support:support-dynamic-animation': 'androidx.dynamicanimation:dynamicanimation',
+    'com.android.support:support-emoji': 'androidx.emoji:emoji',
+    'com.android.support:support-emoji-appcompat': 'androidx.emoji:emoji-appcompat',
+    'com.android.support:support-emoji-bundled': 'androidx.emoji:emoji-bundled',
+    'com.android.support:support-fragment': 'androidx.fragment:fragment',
+    'com.android.support:support-media-compat': 'androidx.media:media',
+    'com.android.support:support-tv-provider': 'androidx.tvprovider:tvprovider',
+    'com.android.support:support-v13': 'androidx.legacy:legacy-support-v13',
+    'com.android.support:support-v4': 'androidx.legacy:legacy-support-v4',
+    'com.android.support:support-vector-drawable': 'androidx.vectordrawable:vectordrawable',
+    'com.android.support:swiperefreshlayout': 'androidx.swiperefreshlayout:swiperefreshlayout',
+    'com.android.support:textclassifier': 'androidx.textclassifier:textclassifier',
+    'com.android.support:transition': 'androidx.transition:transition',
+    'com.android.support:versionedparcelable': 'androidx.versionedparcelable:versionedparcelable',
+    'com.android.support:viewpager': 'androidx.viewpager:viewpager',
+    'com.android.support:wear': 'androidx.wear:wear',
+    'com.android.support:webkit': 'androidx.webkit:webkit'
+}
+
+BUILD_FILE_CONTENT = """
+java_import(
+    name = "jetifier_standalone_jars",
+    jars = glob(["lib/*.jar"]),
+)
+java_binary(
+    main_class = "com.android.tools.build.jetifier.standalone.Main",
+    name = "jetifier_standalone",
+    runtime_deps = [
+        ":jetifier_standalone_jars"
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+
+def jetifier_init():
+    _http_archive(
+        sha256 = "822f53fdcb9d5eeccb8f61ad7a51fe432c76d3cf1310ae63970e61500d66f98e",
+        strip_prefix = "jetifier-standalone",
+        name = "bazel_maven_repository_jetifier",
+        url = "https://dl.google.com/dl/android/studio/jetifier-zips/1.0.0-beta07/jetifier-standalone.zip",
+        build_file_content = BUILD_FILE_CONTENT,
+    )
+
+# _jetify_impl and jetify are based on https://github.com/bazelbuild/tools_android/pull/5
+
+def _jetify_impl(ctx):
+    srcs = ctx.attr.srcs
+    outfiles = []
+    for src in srcs:
+        for artifact in src.files.to_list():
+            jetified_outfile = ctx.actions.declare_file("jetified_" + artifact.basename)
+            jetify_args = ctx.actions.args()
+            jetify_args.add_all(["-l", "error"])
+            jetify_args.add_all(["-o", jetified_outfile])
+            jetify_args.add_all(["-i", artifact])
+            ctx.actions.run(
+                mnemonic = "Jetify",
+                inputs = [artifact],
+                outputs = [jetified_outfile],
+                progress_message = "Jetifying {} to create {}.".format(artifact.path, jetified_outfile.path),
+                executable = ctx.executable._jetifier,
+                arguments = [jetify_args],
+                use_default_shell_env = True,
+            )
+            outfiles.append(jetified_outfile)
+
+    return [DefaultInfo(files = depset(outfiles))]
+
+jetify = rule(
+    attrs = {
+        "srcs": attr.label_list(allow_files = [".jar", ".aar"]),
+        "_jetifier": attr.label(
+            executable = True,
+            allow_files = True,
+            default = Label("@bazel_maven_repository_jetifier//:jetifier_standalone"),
+            cfg = "host",
+        ),
+    },
+    implementation = _jetify_impl,
+)

--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -235,6 +235,19 @@ _generate_maven_repository = repository_rule(
     },
 )
 
+JETIFIER_EXCLUDED_ARTIFACTS = [
+    "javax.annotation:jsr250-api",
+    "com.google.code.findbugs:jsr305",
+    "com.google.errorprone:javac-shaded",
+    "com.google.googlejavaformat:google-java-format",
+    "com.squareup:javapoet",
+    "com.google.dagger:dagger-compiler",
+    "com.google.dagger:dagger-producers",
+    "com.google.dagger:dagger-spi",
+    "com.google.dagger:dagger",
+    "javax.inject:javax.inject",
+]
+
 # Implementation of the maven_jvm_artifact rule.
 def _maven_jvm_artifact(artifact_spec, name, visibility, deps = [], use_jetifier = False, **kwargs):
     artifact = artifacts.annotate(artifacts.parse_spec(artifact_spec))
@@ -243,18 +256,10 @@ def _maven_jvm_artifact(artifact_spec, name, visibility, deps = [], use_jetifier
     target_name = name if name else artifact.third_party_target_name
     coordinate = "%s:%s" % (artifact.group_id, artifact.artifact_id)
 
-    should_jetify = use_jetifier and coordinate not in [
-      "javax.annotation:jsr250-api",
-      "com.google.code.findbugs:jsr305",
-      "com.google.errorprone:javac-shaded",
-      "com.google.googlejavaformat:google-java-format",
-      "com.squareup:javapoet",
-      "com.google.dagger:dagger-compiler",
-      "com.google.dagger:dagger-producers",
-      "com.google.dagger:dagger-spi",
-      "com.google.dagger:dagger",
-      "javax.inject:javax.inject",
-    ] and artifact.group_id != "org.bouncycastle" and not artifact.group_id.startswith("androidx")
+    should_jetify = (use_jetifier and
+        coordinate not in JETIFIER_EXCLUDED_ARTIFACTS and
+        artifact.group_id != "org.bouncycastle" and
+        not artifact.group_id.startswith("androidx"))
 
     if should_jetify:
         target = target_name + "_jetified"

--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -19,6 +19,7 @@ load(":jvm.bzl", "raw_jvm_import")
 load(":poms.bzl", "poms")
 load(":sets.bzl", "sets")
 load(":utils.bzl", "dicts", "paths", "strings")
+load(":jetifier.bzl", "jetifier_init", "jetify")
 
 #enum
 artifact_config_properties = struct(
@@ -88,7 +89,7 @@ load("@{maven_rules_repository}//maven:maven.bzl", "maven_jvm_artifact")
 
 _MAVEN_REPO_TARGET_TEMPLATE = """maven_jvm_artifact(
     name = "{target}",
-    artifact = "{artifact_coordinates}",
+    artifact = "{artifact_coordinates}",{use_jetifier}
 {deps})
 """
 
@@ -213,6 +214,7 @@ def _generate_maven_repository_impl(ctx):
                         target = artifact.third_party_target_name,
                         deps = _deps_string(normalized_deps),
                         artifact_coordinates = artifact.original_spec,
+                        use_jetifier = "\n    use_jetifier = True," if ctx.attr.use_jetifier else ""
                     ),
                 )
         file = "%s/BUILD.bazel" % group_path
@@ -229,19 +231,44 @@ _generate_maven_repository = repository_rule(
         "maven_rules_repository": attr.string(mandatory = False, default = "maven_repository_rules"),
         "dependency_target_substitutes": attr.string_list_dict(mandatory = True),
         "build_snippets": attr.string_dict(mandatory = True),
+        "use_jetifier": attr.bool(default = False),
     },
 )
 
 # Implementation of the maven_jvm_artifact rule.
-def _maven_jvm_artifact(artifact_spec, name, visibility, deps = [], **kwargs):
+def _maven_jvm_artifact(artifact_spec, name, visibility, deps = [], use_jetifier = False, **kwargs):
     artifact = artifacts.annotate(artifacts.parse_spec(artifact_spec))
     maven_target = "@%s//%s:%s" % (artifact.maven_target_name, _DOWNLOAD_PREFIX, artifact.path)
     import_target = artifact.maven_target_name + "_import"
     target_name = name if name else artifact.third_party_target_name
+    coordinate = "%s:%s" % (artifact.group_id, artifact.artifact_id)
+
+    should_jetify = use_jetifier and coordinate not in [
+      "javax.annotation:jsr250-api",
+      "com.google.code.findbugs:jsr305",
+      "com.google.errorprone:javac-shaded",
+      "com.google.googlejavaformat:google-java-format",
+      "com.squareup:javapoet",
+      "com.google.dagger:dagger-compiler",
+      "com.google.dagger:dagger-producers",
+      "com.google.dagger:dagger-spi",
+      "com.google.dagger:dagger",
+      "javax.inject:javax.inject",
+    ] and artifact.group_id != "org.bouncycastle" and not artifact.group_id.startswith("androidx")
+
+    if should_jetify:
+        target = target_name + "_jetified"
+        jetify(
+            name = target,
+            srcs = [maven_target]
+        )
+    else:
+        target = maven_target
+
     if artifact.packaging == "jar":
-        raw_jvm_import(name = target_name, deps = deps, visibility = visibility, jar = maven_target, **kwargs)
+        raw_jvm_import(name = target_name, deps = deps, visibility = visibility, jar = target, **kwargs)
     elif artifact.packaging == "aar":
-        native.aar_import(name = target_name, deps = deps, visibility = visibility, aar = maven_target, **kwargs)
+        native.aar_import(name = target_name, deps = deps, visibility = visibility, aar = target, **kwargs)
     else:
         fail("Packaging %s not supported by maven_jvm_artifact." % artifact.packaging)
 
@@ -335,6 +362,7 @@ def _maven_repository_specification(
         insecure_artifacts = [],
         build_substitutes = {},
         dependency_target_substitutes = {},
+        use_jetifier = False,
         repository_urls = ["https://repo1.maven.org/maven2"]):
     _handle_legacy_specifications(artifact_declarations, insecure_artifacts, build_substitutes)
 
@@ -377,6 +405,7 @@ def _maven_repository_specification(
         repository_urls = repository_urls,
         dependency_target_substitutes = dependency_target_substitutes_rewritten,
         build_snippets = build_snippets,
+        use_jetifier = use_jetifier,
     )
 
 for_testing = struct(
@@ -430,8 +459,13 @@ def maven_repository_specification(
         # "@myreponame//path/to/package:target": "@myrepotarget//path/to/package:alternate"
         dependency_target_substitutes = {},
 
+        #  TODO: Add suppot for opting out from jetifier
+        # use_jetifier = False,
+
         # Optional list of repositories which the build rule will attempt to fetch maven artifacts and metadata.
         repository_urls = ["https://repo1.maven.org/maven2"]):
+    # Define repository rule for the jetifier tooling
+    jetifier_init()
     # Redirected to _maven_repository_specification to allow the public parameter "artifacts" without conflicting
     # with the artifact utility struct.
     _maven_repository_specification(
@@ -440,5 +474,6 @@ def maven_repository_specification(
         insecure_artifacts = insecure_artifacts,
         build_substitutes = build_substitutes,
         dependency_target_substitutes = dependency_target_substitutes,
+        use_jetifier = True,
         repository_urls = repository_urls,
     )

--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -59,9 +59,7 @@ def _process_dependency(dep_node):
     # TODO: Respect use_jetifier from `maven.bzl`
     coordinate = "%s:%s" % (group_id, artifact_id)
     if coordinate in JETIFIER_ARTIFACT_MAPPING:
-        new_coordinate_split = JETIFIER_ARTIFACT_MAPPING[coordinate].split(':')
-        group_id = new_coordinate_split[0]
-        artifact_id = new_coordinate_split[1]
+        group_id, artifact_id = JETIFIER_ARTIFACT_MAPPING[coordinate].split(':')
         version = "unspecified"
 
     return _dependency(

--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -4,6 +4,7 @@
 #
 load(":utils.bzl", "strings")
 load(":xml.bzl", "xml")
+load(":jetifier.bzl", "JETIFIER_ARTIFACT_MAPPING")
 
 # An enum of known labels
 labels = struct(
@@ -54,6 +55,14 @@ def _process_dependency(dep_node):
             optional = bool(c.content)
         elif c.label == labels.SYSTEM_PATH:
             system_path = c.content
+
+    # TODO: Respect use_jetifier from `maven.bzl`
+    coordinate = "%s:%s" % (group_id, artifact_id)
+    if coordinate in JETIFIER_ARTIFACT_MAPPING:
+        new_coordinate_split = JETIFIER_ARTIFACT_MAPPING[coordinate].split(':')
+        group_id = new_coordinate_split[0]
+        artifact_id = new_coordinate_split[1]
+        version = "unspecified"
 
     return _dependency(
         group_id = group_id,


### PR DESCRIPTION
This change covers two aspects:
* Artifact mapping - based on list available here https://developer.android.com/jetpack/androidx/migrate/artifact-mappings all artfiacts "mentioned" in POMs (in dependencies) are mapped to AndroidX artifacts
* Rewriting .jar's and .aar's using jetifier-standalone so they reference (import) correct (Androidx) packages (there is basic/hardcoded support for excluding certain artfiacts, such as android.* or bouncycastle)

> Note: This won't add flagging of the feature on and off, which will come in a subsequent PR. 