### PR TITLE
Fix off-by-one IndexError in _merge_leaf_elements

### DIFF
--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -264,7 +264,7 @@ def _merge_leaf_elements(parent_list, child_list):
             merged[index_of_property] = child_list[i]
         else:
             merged.append(child_list[i])
-            index[child_list[i].label] = len(merged)
+            index[child_list[i].label] = len(merged) - 1
     return merged
 
 def _children_if_exists(node):


### PR DESCRIPTION
Using the length of the `merged` list as an index is incorrect. 

This bug came up when merging `pom.xml` `<properties>`; finding an already-found (e.g.; duplicate/overriding) XML node label leads to a memoized, off-by-one index being used.

To reproduce, attempt to use the `com.sun.activation:javax.activation:1.2.0` artifact ([`pom.xml`](https://repo1.maven.org/maven2/com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.pom)). This will bring in parent `pom.xml`s from [`com.sun.activation:all:1.2.0`](https://repo1.maven.org/maven2/com/sun/activation/all/1.2.0/all-1.2.0.pom) and [`net.java:jvnet-parent:1`](https://repo1.maven.org/maven2/net/java/jvnet-parent/1/jvnet-parent-1.pom), the former having a duplicate property (`activation.bundle.symbolicName`) which triggers this.