### PR TITLE
Pull in Jettifier support from the 1.0 side branch. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
   matrix:
     - USE_BAZEL_VERSION="0.29.0" SEGMENT="."
     - USE_BAZEL_VERSION="0.29.0" SEGMENT="test/test_workspace"
+    - USE_BAZEL_VERSION="0.29.1" SEGMENT="."
+    - USE_BAZEL_VERSION="0.29.1" SEGMENT="test/test_workspace"
+    - USE_BAZEL_VERSION="1.0.0" SEGMENT="."
+    - USE_BAZEL_VERSION="1.0.0" SEGMENT="test/test_workspace"
 
 addons:
   apt:

--- a/maven/jetifier.bzl
+++ b/maven/jetifier.bzl
@@ -1,0 +1,170 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
+
+# Based on https://developer.android.com/jetpack/androidx/migrate/artifact-mappings
+JETIFIER_ARTIFACT_MAPPING = {
+    'android.arch.core:common': 'androidx.arch.core:core-common',
+    'android.arch.core:core': 'androidx.arch.core:core',
+    'android.arch.core:core-testing': 'androidx.arch.core:core-testing',
+    'android.arch.core:runtime': 'androidx.arch.core:core-runtime',
+    'android.arch.lifecycle:common': 'androidx.lifecycle:lifecycle-common',
+    'android.arch.lifecycle:common-java8': 'androidx.lifecycle:lifecycle-common-java8',
+    'android.arch.lifecycle:compiler': 'androidx.lifecycle:lifecycle-compiler',
+    'android.arch.lifecycle:extensions': 'androidx.lifecycle:lifecycle-extensions',
+    'android.arch.lifecycle:livedata': 'androidx.lifecycle:lifecycle-livedata',
+    'android.arch.lifecycle:livedata-core': 'androidx.lifecycle:lifecycle-livedata-core',
+    'android.arch.lifecycle:reactivestreams': 'androidx.lifecycle:lifecycle-reactivestreams',
+    'android.arch.lifecycle:runtime': 'androidx.lifecycle:lifecycle-runtime',
+    'android.arch.lifecycle:viewmodel': 'androidx.lifecycle:lifecycle-viewmodel',
+    'android.arch.paging:common': 'androidx.paging:paging-common',
+    'android.arch.paging:runtime': 'androidx.paging:paging-runtime',
+    'android.arch.paging:rxjava2': 'androidx.paging:paging-rxjava2',
+    'android.arch.persistence.room:common': 'androidx.room:room-common',
+    'android.arch.persistence.room:compiler': 'androidx.room:room-compiler',
+    'android.arch.persistence.room:guava': 'androidx.room:room-guava',
+    'android.arch.persistence.room:migration': 'androidx.room:room-migration',
+    'android.arch.persistence.room:runtime': 'androidx.room:room-runtime',
+    'android.arch.persistence.room:rxjava2': 'androidx.room:room-rxjava2',
+    'android.arch.persistence.room:testing': 'androidx.room:room-testing',
+    'android.arch.persistence:db': 'androidx.sqlite:sqlite',
+    'android.arch.persistence:db-framework': 'androidx.sqlite:sqlite-framework',
+    'com.android.support.constraint:constraint-layout': 'androidx.constraintlayout:constraintlayout',
+    'com.android.support.constraint:constraint-layout-solver': 'androidx.constraintlayout:constraintlayout-solver',
+    'com.android.support.test.espresso.idling:idling-concurrent': 'androidx.test.espresso.idling:idling-concurrent',
+    'com.android.support.test.espresso.idling:idling-net': 'androidx.test.espresso.idling:idling-net',
+    'com.android.support.test.espresso:espresso-accessibility': 'androidx.test.espresso:espresso-accessibility',
+    'com.android.support.test.espresso:espresso-contrib': 'androidx.test.espresso:espresso-contrib',
+    'com.android.support.test.espresso:espresso-core': 'androidx.test.espresso:espresso-core',
+    'com.android.support.test.espresso:espresso-idling-resource': 'androidx.test.espresso:espresso-idling-resource',
+    'com.android.support.test.espresso:espresso-intents': 'androidx.test.espresso:espresso-intents',
+    'com.android.support.test.espresso:espresso-remote': 'androidx.test.espresso:espresso-remote',
+    'com.android.support.test.espresso:espresso-web': 'androidx.test.espresso:espresso-web',
+    'com.android.support.test.janktesthelper:janktesthelper': 'androidx.test.jank:janktesthelper',
+    'com.android.support.test.services:test-services': 'androidx.test:test-services',
+    'com.android.support.test.uiautomator:uiautomator': 'androidx.test.uiautomator:uiautomator',
+    'com.android.support.test:monitor': 'androidx.test:monitor',
+    'com.android.support.test:orchestrator': 'androidx.test:orchestrator',
+    'com.android.support.test:rules': 'androidx.test:rules',
+    'com.android.support.test:runner': 'androidx.test:runner',
+    'com.android.support:animated-vector-drawable': 'androidx.vectordrawable:vectordrawable-animated',
+    'com.android.support:appcompat-v7': 'androidx.appcompat:appcompat',
+    'com.android.support:asynclayoutinflater': 'androidx.asynclayoutinflater:asynclayoutinflater',
+    'com.android.support:car': 'androidx.car:car',
+    'com.android.support:cardview-v7': 'androidx.cardview:cardview',
+    'com.android.support:collections': 'androidx.collection:collection',
+    'com.android.support:coordinatorlayout': 'androidx.coordinatorlayout:coordinatorlayout',
+    'com.android.support:cursoradapter': 'androidx.cursoradapter:cursoradapter',
+    'com.android.support:customtabs': 'androidx.browser:browser',
+    'com.android.support:customview': 'androidx.customview:customview',
+    'com.android.support:design': 'com.google.android.material:material',
+    'com.android.support:documentfile': 'androidx.documentfile:documentfile',
+    'com.android.support:drawerlayout': 'androidx.drawerlayout:drawerlayout',
+    'com.android.support:exifinterface': 'androidx.exifinterface:exifinterface',
+    'com.android.support:gridlayout-v7': 'androidx.gridlayout:gridlayout',
+    'com.android.support:heifwriter': 'androidx.heifwriter:heifwriter',
+    'com.android.support:interpolator': 'androidx.interpolator:interpolator',
+    'com.android.support:leanback-v17': 'androidx.leanback:leanback',
+    'com.android.support:loader': 'androidx.loader:loader',
+    'com.android.support:localbroadcastmanager': 'androidx.localbroadcastmanager:localbroadcastmanager',
+    'com.android.support:media2': 'androidx.media2:media2',
+    'com.android.support:media2-exoplayer': 'androidx.media2:media2-exoplayer',
+    'com.android.support:mediarouter-v7': 'androidx.mediarouter:mediarouter',
+    'com.android.support:multidex': 'androidx.multidex:multidex',
+    'com.android.support:multidex-instrumentation': 'androidx.multidex:multidex-instrumentation',
+    'com.android.support:palette-v7': 'androidx.palette:palette',
+    'com.android.support:percent': 'androidx.percentlayout:percentlayout',
+    'com.android.support:preference-leanback-v17': 'androidx.leanback:leanback-preference',
+    'com.android.support:preference-v14': 'androidx.legacy:legacy-preference-v14',
+    'com.android.support:preference-v7': 'androidx.preference:preference',
+    'com.android.support:print': 'androidx.print:print',
+    'com.android.support:recommendation': 'androidx.recommendation:recommendation',
+    'com.android.support:recyclerview-selection': 'androidx.recyclerview:recyclerview-selection',
+    'com.android.support:recyclerview-v7': 'androidx.recyclerview:recyclerview',
+    'com.android.support:slices-builders': 'androidx.slice:slice-builders',
+    'com.android.support:slices-core': 'androidx.slice:slice-core',
+    'com.android.support:slices-view': 'androidx.slice:slice-view',
+    'com.android.support:slidingpanelayout': 'androidx.slidingpanelayout:slidingpanelayout',
+    'com.android.support:support-annotations': 'androidx.annotation:annotation',
+    'com.android.support:support-compat': 'androidx.core:core',
+    'com.android.support:support-content': 'androidx.contentpager:contentpager',
+    'com.android.support:support-core-ui': 'androidx.legacy:legacy-support-core-ui',
+    'com.android.support:support-core-utils': 'androidx.legacy:legacy-support-core-utils',
+    'com.android.support:support-dynamic-animation': 'androidx.dynamicanimation:dynamicanimation',
+    'com.android.support:support-emoji': 'androidx.emoji:emoji',
+    'com.android.support:support-emoji-appcompat': 'androidx.emoji:emoji-appcompat',
+    'com.android.support:support-emoji-bundled': 'androidx.emoji:emoji-bundled',
+    'com.android.support:support-fragment': 'androidx.fragment:fragment',
+    'com.android.support:support-media-compat': 'androidx.media:media',
+    'com.android.support:support-tv-provider': 'androidx.tvprovider:tvprovider',
+    'com.android.support:support-v13': 'androidx.legacy:legacy-support-v13',
+    'com.android.support:support-v4': 'androidx.legacy:legacy-support-v4',
+    'com.android.support:support-vector-drawable': 'androidx.vectordrawable:vectordrawable',
+    'com.android.support:swiperefreshlayout': 'androidx.swiperefreshlayout:swiperefreshlayout',
+    'com.android.support:textclassifier': 'androidx.textclassifier:textclassifier',
+    'com.android.support:transition': 'androidx.transition:transition',
+    'com.android.support:versionedparcelable': 'androidx.versionedparcelable:versionedparcelable',
+    'com.android.support:viewpager': 'androidx.viewpager:viewpager',
+    'com.android.support:wear': 'androidx.wear:wear',
+    'com.android.support:webkit': 'androidx.webkit:webkit'
+}
+
+BUILD_FILE_CONTENT = """
+java_import(
+    name = "jetifier_standalone_jars",
+    jars = glob(["lib/*.jar"]),
+)
+java_binary(
+    main_class = "com.android.tools.build.jetifier.standalone.Main",
+    name = "jetifier_standalone",
+    runtime_deps = [
+        ":jetifier_standalone_jars"
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+
+def jetifier_init():
+    _http_archive(
+        sha256 = "822f53fdcb9d5eeccb8f61ad7a51fe432c76d3cf1310ae63970e61500d66f98e",
+        strip_prefix = "jetifier-standalone",
+        name = "bazel_maven_repository_jetifier",
+        url = "https://dl.google.com/dl/android/studio/jetifier-zips/1.0.0-beta07/jetifier-standalone.zip",
+        build_file_content = BUILD_FILE_CONTENT,
+    )
+
+# _jetify_impl and jetify are based on https://github.com/bazelbuild/tools_android/pull/5
+
+def _jetify_impl(ctx):
+    srcs = ctx.attr.srcs
+    outfiles = []
+    for src in srcs:
+        for artifact in src.files.to_list():
+            jetified_outfile = ctx.actions.declare_file("jetified_" + artifact.basename)
+            jetify_args = ctx.actions.args()
+            jetify_args.add_all(["-l", "error"])
+            jetify_args.add_all(["-o", jetified_outfile])
+            jetify_args.add_all(["-i", artifact])
+            ctx.actions.run(
+                mnemonic = "Jetify",
+                inputs = [artifact],
+                outputs = [jetified_outfile],
+                progress_message = "Jetifying {} to create {}.".format(artifact.path, jetified_outfile.path),
+                executable = ctx.executable._jetifier,
+                arguments = [jetify_args],
+                use_default_shell_env = True,
+            )
+            outfiles.append(jetified_outfile)
+
+    return [DefaultInfo(files = depset(outfiles))]
+
+jetify = rule(
+    attrs = {
+        "srcs": attr.label_list(allow_files = [".jar", ".aar"]),
+        "_jetifier": attr.label(
+            executable = True,
+            allow_files = True,
+            default = Label("@bazel_maven_repository_jetifier//:jetifier_standalone"),
+            cfg = "host",
+        ),
+    },
+    implementation = _jetify_impl,
+)

--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -440,7 +440,6 @@ def maven_repository_specification(
 
         sha256 = properties.get(artifact_config_properties.SHA256)
 
-        # TODO: Make this a more generalized exclusion list (and move
         should_jetify = (use_jetifier and
             artifact.coordinates not in JETIFIER_EXCLUDED_ARTIFACTS and
             artifact.group_id != "org.bouncycastle" and

--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -403,8 +403,7 @@ def _get_inheritance_chain(ctx, artifact):
     inheritance_chain = []
     current = artifact
     for _ in range(100):  # Can't use recursion, so just iterate
-        if not bool(current):
-            ctx.report_progress("Merging poms for %s" % artifact.original_spec)
+        if current == None:
             return inheritance_chain
         path = ctx.path(fetch_repo.pom_target_relative_to(current, fetch_repo.pom_repo_name(artifact)))
         ctx.report_progress("Reading pom for %s" % current.original_spec)

--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -6,6 +6,7 @@ load(":globals.bzl", "DOWNLOAD_PREFIX", "fetch_repo")
 load(":packaging_type.bzl", "packaging_type")
 load(":utils.bzl", "strings")
 load(":xml.bzl", "xml")
+load(":jetifier.bzl", "JETIFIER_ARTIFACT_MAPPING")
 
 # An enum of known labels
 labels = struct(
@@ -56,6 +57,12 @@ def _process_dependency(dep_node):
             optional = strings.trim(c.content).lower() == "true"
         elif c.label == labels.SYSTEM_PATH:
             system_path = c.content
+
+    # TODO: Respect use_jetifier from `maven.bzl`
+    coordinate = "%s:%s" % (group_id, artifact_id)
+    if coordinate in JETIFIER_ARTIFACT_MAPPING:
+        group_id, artifact_id = JETIFIER_ARTIFACT_MAPPING[coordinate].split(':')
+        version = "unspecified"
 
     return _dependency(
         group_id = group_id,

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -16,7 +16,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 KOTLIN_VERSION = "1.3.50"
 KOTLINC_ROOT = "https://github.com/JetBrains/kotlin/releases/download"
-KOTLINC_SHA = "107325d56315af4f59ff28db6837d03c2660088e3efeb7d4e41f3e01bb848d6a"
+KOTLINC_SHA = "69424091a6b7f52d93eed8bba2ace921b02b113dbb71388d704f8180a6bdc6ec"
 KOTLIN_RULES_VERSION = "sq_02"
 KOTLIN_RULES_SHA = "03606649fb705d114ef7ca05de38551614c1530cda22fb39d973bd0d3aa69c22"
 

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -14,11 +14,11 @@ load(
 )
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-KOTLIN_VERSION = "1.3.31"
+KOTLIN_VERSION = "1.3.50"
 KOTLINC_ROOT = "https://github.com/JetBrains/kotlin/releases/download"
 KOTLINC_SHA = "107325d56315af4f59ff28db6837d03c2660088e3efeb7d4e41f3e01bb848d6a"
-KOTLIN_RULES_VERSION = "legacy-modded-0_26_1-02"
-KOTLIN_RULES_SHA = "245d0bc1511048aaf82afd0fa8a83e8c3b5afdff0ae4fbcae25e03bb2c6f1a1a"
+KOTLIN_RULES_VERSION = "sq_02"
+KOTLIN_RULES_SHA = "03606649fb705d114ef7ca05de38551614c1530cda22fb39d973bd0d3aa69c22"
 
 http_archive(
     name = "io_bazel_rules_kotlin",
@@ -114,7 +114,7 @@ maven_repository_specification(
     },
     repository_urls = [
         "https://repo1.maven.org/maven2",
-        "http://maven.google.com"
+        "https://maven.google.com"
     ],
 
     # Because these apply to all targets within a group, it's specified separately from the artifact list.


### PR DESCRIPTION
This pulls in @inez' support from the 1.0.x maintenance branch, and adapts it to the new structure.  It also tidies up a few things about error reporting for missing deps. It also updates the test workspace so it can run against bazel 1.0 (by using the latest kotlin rules) 