### PR TITLE
Make jetifier support configurable.

### DIFF
--- a/maven/poms.bzl
+++ b/maven/poms.bzl
@@ -6,7 +6,6 @@ load(":globals.bzl", "DOWNLOAD_PREFIX", "fetch_repo")
 load(":packaging_type.bzl", "packaging_type")
 load(":utils.bzl", "strings")
 load(":xml.bzl", "xml")
-load(":jetifier.bzl", "JETIFIER_ARTIFACT_MAPPING")
 
 # An enum of known labels
 labels = struct(
@@ -57,12 +56,6 @@ def _process_dependency(dep_node):
             optional = strings.trim(c.content).lower() == "true"
         elif c.label == labels.SYSTEM_PATH:
             system_path = c.content
-
-    # TODO: Respect use_jetifier from `maven.bzl`
-    coordinate = "%s:%s" % (group_id, artifact_id)
-    if coordinate in JETIFIER_ARTIFACT_MAPPING:
-        group_id, artifact_id = JETIFIER_ARTIFACT_MAPPING[coordinate].split(':')
-        version = "unspecified"
 
     return _dependency(
         group_id = group_id,
@@ -466,4 +459,6 @@ poms = struct(
     # performed.  This function assumes that a fetch.pom_rule has been setup for the artifact in question, that it has
     # been passed to the rules invoking this function, and will fail with a missing workspace if that is not the case.
     get_project_metadata = _get_project_metadata,
+
+    dependency = _dependency,
 )

--- a/maven/tests/poms_for_testing.bzl
+++ b/maven/tests/poms_for_testing.bzl
@@ -124,9 +124,9 @@ COMPLEX_POM = POM_PREFIX + """
       <version>${findbugs.jsr305}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.dagger</groupId>
-      <artifactId>dagger</artifactId>
-      <version>2.16</version>
+      <groupId>com.android.support</groupId>
+      <artifactId>support-annotations</artifactId>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.mojo</groupId>
@@ -174,9 +174,9 @@ MERGED_EXPECTED_POM = POM_PREFIX + """
       <version>${findbugs.jsr305}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.dagger</groupId>
-      <artifactId>dagger</artifactId>
-      <version>2.16</version>
+      <groupId>com.android.support</groupId>
+      <artifactId>support-annotations</artifactId>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.mojo</groupId>

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -54,6 +54,9 @@ maven_repository_specification(
     # Enable the creation of older-style mangling where foo-bar becomes foo_bar (for migration)
     legacy_artifact_id_munge = True,
 
+    # Substitute old android artifacts in poms' deps for androidx ones, and process jars.
+    use_jetifier = True,
+
     # The artifact spec list.
     artifacts = {
         # This is the proper way to specify an artifact.  It contains the artifact, plus a configuration dictionary.
@@ -109,12 +112,15 @@ maven_repository_specification(
         "org.reflections:reflections:0.9.11": {"insecure": True }, # test leniency related to #62.
         "org.javassist:javassist:3.21.0-GA": {"insecure": True}, # Only needed if #62 is fixed.
         "androidx.arch.core:core-runtime:2.0.0": {"insecure": True},
-        "androidx.annotation:annotation:1.0.2": {"insecure": True},
-        "androidx.arch.core:core-common:2.0.0": {"insecure": True},
+        "androidx.annotation:annotation:1.0.0": { "insecure": True },
+        "androidx.arch.core:core-common:2.0.0": { "insecure": True },
+
+        # Legacy android dep. Uncommenting this will cause an error if use_jetifier = True.
+        # "com.android.support:support-v4:26.1.0:aar": { "insecure": True },
     },
     repository_urls = [
         "https://repo1.maven.org/maven2",
-        "https://maven.google.com"
+        "https://maven.google.com",
     ],
 
     # Because these apply to all targets within a group, it's specified separately from the artifact list.


### PR DESCRIPTION
Make it so that the jetifier mechanisms (both deps substitution and artifact processing) respect the attribute of the maven_repository_specification() macro.

Also, improve the output of missing deps. 