### PR TITLE
Expand aars during repository creation.

### DIFF
--- a/maven/jetifier.bzl
+++ b/maven/jetifier.bzl
@@ -138,7 +138,7 @@ def _jetify_impl(ctx):
     outfiles = []
     for src in srcs:
         for artifact in src.files.to_list():
-            jetified_outfile = ctx.actions.declare_file("jetified_" + artifact.basename)
+            jetified_outfile = ctx.actions.declare_file(ctx.attr.name + "_jetified_" + artifact.basename)
             jetify_args = ctx.actions.args()
             jetify_args.add_all(["-l", "error"])
             jetify_args.add_all(["-o", jetified_outfile])

--- a/maven/jvm.bzl
+++ b/maven/jvm.bzl
@@ -38,7 +38,10 @@ def _raw_jvm_import(ctx):
     Supplied jar parameter (%s) transitively included more than one binary jar and one (optional)
     source jar.  Found: %s, %s""" % (ctx.file.jar, jars, source_jars))
 
-    default_info = DefaultInfo(files = depset(jars))
+    default_info = DefaultInfo(
+        files = depset(jars),
+        runfiles = ctx.runfiles(jars)
+        )
     java_info = JavaInfo(
         output_jar = jars[0],
         compile_jar = jars[0],

--- a/maven/tests/maven_test.bzl
+++ b/maven/tests/maven_test.bzl
@@ -47,7 +47,7 @@ def get_pom_test(env):
         attr = struct(repository_urls = [_FAKE_URL_PREFIX])
     )
     project = poms.parse(
-        for_testing.fetch_pom(fake_ctx, artifacts.annotate(artifacts.parse_spec("test.group:child:1.0"))))
+        for_testing.fetch_pom(fake_ctx, artifacts.annotate(artifacts.parse_spec("test.group:child:1.0")), {}))
     asserts.equals(env, "project", project.label)
 
 
@@ -74,7 +74,7 @@ def get_parent_chain_test(env):
         execute = _fake_cat_for_get_parent_chain,
         attr = struct(repository_urls = [_FAKE_URL_PREFIX])
     )
-    chain = for_testing.get_inheritance_chain(fake_ctx, COMPLEX_POM)
+    chain = for_testing.get_inheritance_chain(fake_ctx, COMPLEX_POM, {})
     asserts.equals(env, ["child", "parent", "grandparent"], [_extract_artifact_id(x) for x in chain])
 
 def get_effective_pom_test(env):


### PR DESCRIPTION
This ensures that aar contents work the same as standard android_library rules. Will result in a small performance bump for large numbers of maven repositories as the aar will no longer be expanded at build time.

Additional changes:
* ensure that the jars in raw_jvm_import are passed to the runfiles
* runtime cache for repeated fetching pom files
* progress tracking during pom fetching and build file generation.