### PR TITLE
Support source jar propagation.

### DIFF
--- a/kramer/WORKSPACE
+++ b/kramer/WORKSPACE
@@ -97,7 +97,7 @@ maven_repository_specification(
             "insecure": True,
             "build_snippet": OKIO_SNIPPET,
         },
-        "com.squareup.tools.build:maven-archeologist:0.0.3.1": {"insecure": True},
+        "com.squareup.tools.build:maven-archeologist:0.0.4": {"insecure": True},
         "junit:junit:4.13": {
             "insecure": True,
             "testonly": True,

--- a/kramer/src/main/kotlin/kramer/GenerateMavenRepoCommand.kt
+++ b/kramer/src/main/kotlin/kramer/GenerateMavenRepoCommand.kt
@@ -219,7 +219,6 @@ class GenerateMavenRepo(
       else -> mavenJarTemplate(
         target = resolved.target,
         coordinate = resolved.coordinate,
-        jarPath = "${resolved.main.path}",
         jetify = jetify,
         deps = deps,
         fetchRepo = resolved.fetchRepoPackage(),

--- a/kramer/src/test/kotlin/kramer/JetifierTest.kt
+++ b/kramer/src/test/kotlin/kramer/JetifierTest.kt
@@ -18,6 +18,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.tools.maven.resolution.ArtifactFetcher
 import com.squareup.tools.maven.resolution.ArtifactFile
 import com.squareup.tools.maven.resolution.ArtifactResolver
+import com.squareup.tools.maven.resolution.FileSpec
 import com.squareup.tools.maven.resolution.PomFile
 import java.nio.file.Paths
 import org.apache.maven.model.Repository
@@ -83,6 +84,9 @@ class JetifierTest {
     private val resolver = ArtifactResolver(
       fetcher = object : ArtifactFetcher {
         override fun fetchArtifact(artifactFile: ArtifactFile, repositories: List<Repository>) =
+          throw UnsupportedOperationException("Fake")
+
+        override fun fetchFile(fetchFile: FileSpec, repositories: List<Repository>) =
           throw UnsupportedOperationException("Fake")
 
         override fun fetchPom(pom: PomFile, repositories: List<Repository>) =

--- a/kramer/src/test/kotlin/kramer/integration/FetchArtifactIntegrationTest.kt
+++ b/kramer/src/test/kotlin/kramer/integration/FetchArtifactIntegrationTest.kt
@@ -22,7 +22,6 @@ import com.squareup.tools.maven.resolution.Repositories.MAVEN_CENTRAL
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
-import kramer.AAR_DOWNLOAD_BUILD_FILE
 import kramer.FetchArtifactCommand
 import kramer.Kramer
 import org.junit.Test
@@ -53,7 +52,7 @@ class FetchArtifactIntegrationTest {
     fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.pom")
     fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.jar")
     val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
-    assertThat(build).contains("srcs = [\"com/google/guava/guava/18.0/guava-18.0.jar\"]")
+    assertThat(build).contains("com/google/guava/guava/18.0/guava-18.0.jar")
   }
 
   @Test fun fetchJarWithSha() {
@@ -66,7 +65,17 @@ class FetchArtifactIntegrationTest {
     fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.pom")
     fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.jar")
     val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
-    assertThat(build).contains("srcs = [\"com/google/guava/guava/18.0/guava-18.0.jar\"]")
+    assertThat(build).contains("com/google/guava/guava/18.0/guava-18.0.jar")
+  }
+
+  @Test fun fetchJarInsecurelyWithSources() {
+    val output = cmd.test(flags("com.google.guava:guava:18.0"), baos)
+    assertThat(output).contains("Fetched com.google.guava:guava:18.0 insecurely in")
+    fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.pom")
+    fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.jar")
+    val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
+    assertThat(build).contains("com/google/guava/guava/18.0/guava-18.0.jar")
+    assertThat(build).contains("com/google/guava/guava/18.0/guava-18.0-sources.jar")
   }
 
   @Test fun fetchAarInsecurely() {
@@ -76,7 +85,20 @@ class FetchArtifactIntegrationTest {
     fetchCommand.assertExists("classes.jar")
     fetchCommand.assertExists("AndroidManifest.xml")
     val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
-    assertThat(build).contains(AAR_DOWNLOAD_BUILD_FILE)
+    assertThat(build).contains("classes.jar")
+    assertThat(build).contains("AndroidManifest.xml")
+  }
+
+  @Test fun fetchAarInsecurelyWithSources() {
+    val output = cmd.test(flags("androidx.core:core:1.1.0"), baos)
+    assertThat(output).contains("Fetched androidx.core:core:1.1.0 insecurely in")
+    fetchCommand.assertExists("androidx/core/core/1.1.0/core-1.1.0.pom")
+    fetchCommand.assertExists("classes.jar")
+    fetchCommand.assertExists("AndroidManifest.xml")
+    val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
+    assertThat(build).contains("classes.jar")
+    assertThat(build).contains("AndroidManifest.xml")
+    assertThat(build).contains("androidx/core/core/1.1.0/core-1.1.0-sources.jar")
   }
 
   @Test fun testUnavailableArtifact() {

--- a/kramer/src/test/kotlin/kramer/integration/GenerateMavenRepoIntegrationTest.kt
+++ b/kramer/src/test/kotlin/kramer/integration/GenerateMavenRepoIntegrationTest.kt
@@ -62,6 +62,10 @@ class GenerateMavenRepoIntegrationTest {
     assertThat(output).contains("Building workspace for 1 artifacts")
     assertThat(output).contains("Generated 1 build files in ")
     assertThat(output).contains("Resolved 1 artifacts with 100 threads in")
+    val build = mavenRepo.readBuildFile("javax.inject")
+    assertThat(build).contains("javax.inject:javax.inject:1")
+    assertThat(build).contains("name = \"javax_inject\"")
+    assertThat(build).contains("@javax_inject_javax_inject//maven")
   }
 
   @Test fun excludesSuccess() {
@@ -124,9 +128,9 @@ class GenerateMavenRepoIntegrationTest {
     assertThat(output).contains("Generated 2 build files in ")
     assertThat(output).contains("Resolved 2 artifacts with 100 threads in")
 
-    val guava = mavenRepo.readBuildFile("com.squareup.picasso")
-    assertThat(guava).contains("jetify = True")
-    assertThat(guava).contains("@maven//androidx/annotation")
+    val picasso = mavenRepo.readBuildFile("com.squareup.picasso")
+    assertThat(picasso).contains("jetify = True")
+    assertThat(picasso).contains("@maven//androidx/annotation")
   }
 
   @Test fun jetifierMapMissingArtifact() {


### PR DESCRIPTION
Upgrades maven-archeologist to 0.0.4 which has sub-artifact fetchign capability.

Uses this to (if possible) download a sources.jar for the given artifact, and propagates it through a filegroup so raw_jvm_import appropriately specifies it. This permits IntelliJ (or anthing else that consumes source_jar metadata to provide the sources to the developer.

Fixes #44