### PR TITLE
Improve IDE usability by altering .jar library filename.

### DIFF
--- a/kramer/src/test/kotlin/kramer/integration/FetchArtifactIntegrationTest.kt
+++ b/kramer/src/test/kotlin/kramer/integration/FetchArtifactIntegrationTest.kt
@@ -50,9 +50,9 @@ class FetchArtifactIntegrationTest {
     val output = cmd.test(flags("com.google.guava:guava:18.0"), baos)
     assertThat(output).contains("Fetched com.google.guava:guava:18.0 insecurely in")
     fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.pom")
-    fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.jar")
+    fetchCommand.assertExists("com/google/guava/guava/18.0/maven-bundle-guava-18.0-classes.jar")
     val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
-    assertThat(build).contains("com/google/guava/guava/18.0/guava-18.0.jar")
+    assertThat(build).contains("com/google/guava/guava/18.0/maven-bundle-guava-18.0-classes.jar")
   }
 
   @Test fun fetchJarWithSha() {
@@ -63,18 +63,18 @@ class FetchArtifactIntegrationTest {
     assertThat(output).contains("Fetched com.google.guava:guava:18.0 in")
     assertThat(output).doesNotContain("SHA256")
     fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.pom")
-    fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.jar")
+    fetchCommand.assertExists("com/google/guava/guava/18.0/maven-bundle-guava-18.0-classes.jar")
     val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
-    assertThat(build).contains("com/google/guava/guava/18.0/guava-18.0.jar")
+    assertThat(build).contains("com/google/guava/guava/18.0/maven-bundle-guava-18.0-classes.jar")
   }
 
   @Test fun fetchJarInsecurelyWithSources() {
     val output = cmd.test(flags("com.google.guava:guava:18.0"), baos)
     assertThat(output).contains("Fetched com.google.guava:guava:18.0 insecurely in")
     fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.pom")
-    fetchCommand.assertExists("com/google/guava/guava/18.0/guava-18.0.jar")
+    fetchCommand.assertExists("com/google/guava/guava/18.0/maven-bundle-guava-18.0-classes.jar")
     val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
-    assertThat(build).contains("com/google/guava/guava/18.0/guava-18.0.jar")
+    assertThat(build).contains("com/google/guava/guava/18.0/maven-bundle-guava-18.0-classes.jar")
     assertThat(build).contains("com/google/guava/guava/18.0/guava-18.0-sources.jar")
   }
 
@@ -82,10 +82,10 @@ class FetchArtifactIntegrationTest {
     val output = cmd.test(flags("androidx.core:core:1.1.0"), baos)
     assertThat(output).contains("Fetched androidx.core:core:1.1.0 insecurely in")
     fetchCommand.assertExists("androidx/core/core/1.1.0/core-1.1.0.pom")
-    fetchCommand.assertExists("classes.jar")
+    fetchCommand.assertExists("androidx/core/core/1.1.0/maven-aar-core-1.1.0-classes.jar")
     fetchCommand.assertExists("AndroidManifest.xml")
     val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
-    assertThat(build).contains("classes.jar")
+    assertThat(build).contains("androidx/core/core/1.1.0/maven-aar-core-1.1.0-classes.jar")
     assertThat(build).contains("AndroidManifest.xml")
   }
 
@@ -93,10 +93,10 @@ class FetchArtifactIntegrationTest {
     val output = cmd.test(flags("androidx.core:core:1.1.0"), baos)
     assertThat(output).contains("Fetched androidx.core:core:1.1.0 insecurely in")
     fetchCommand.assertExists("androidx/core/core/1.1.0/core-1.1.0.pom")
-    fetchCommand.assertExists("classes.jar")
+    fetchCommand.assertExists("androidx/core/core/1.1.0/maven-aar-core-1.1.0-classes.jar")
     fetchCommand.assertExists("AndroidManifest.xml")
     val build = Files.readAllLines(fetchCommand.dir.resolve("BUILD.bazel")).joinToString("\n")
-    assertThat(build).contains("classes.jar")
+    assertThat(build).contains("androidx/core/core/1.1.0/maven-aar-core-1.1.0-classes.jar")
     assertThat(build).contains("AndroidManifest.xml")
     assertThat(build).contains("androidx/core/core/1.1.0/core-1.1.0-sources.jar")
   }

--- a/maven/artifacts.bzl
+++ b/maven/artifacts.bzl
@@ -15,7 +15,6 @@
 # Utilities for processing maven artifact coordinates.
 #
 
-_artifact_template = "{group_path}/{artifact_id}/{version}/{artifact_id}-{version}.{suffix}"
 
 # Builds a struct containing the basic coordinate elements of a maven artifact spec.
 def _parse_spec(artifact_spec):
@@ -40,19 +39,7 @@ def _fetch_repo(artifact):
     artifact_elements = artifact.artifact_id.replace("-", ".").split(".")
     return "_".join(group_elements + artifact_elements).replace("-", "_")
 
-def _package_path(artifact):
-    return artifact.group_id.replace(".", "/")
-
-def _artifact_path(artifact, suffix, classifier = None):
-    return _artifact_template.format(
-        group_path = _package_path(artifact),
-        artifact_id = artifact.artifact_id,
-        version = artifact.version,
-        suffix = suffix,
-    )
-
 artifacts = struct(
-    artifact_path = _artifact_path,
     parse_spec = _parse_spec,
     fetch_repo = _fetch_repo,
 )

--- a/maven/jetifier.bzl
+++ b/maven/jetifier.bzl
@@ -55,7 +55,8 @@ def jetifier_init():
 
 # jetify_jar based on https://github.com/bazelbuild/tools_android/pull/5
 def jetify_jar(ctx, jar):
-    jetified_outfile = ctx.actions.declare_file("%s-jetified.%s" % (ctx.attr.name, jar.extension))
+    basename = jar.basename.rsplit(".", 1)[0]
+    jetified_outfile = ctx.actions.declare_file("%s-jetified.%s" % (basename, jar.extension))
     jetify_args = ctx.actions.args()
     jetify_args.add_all(["-l", "error"])
     jetify_args.add_all(["-o", jetified_outfile])

--- a/maven/maven.bzl
+++ b/maven/maven.bzl
@@ -124,10 +124,23 @@ def _validate_artifacts(artifact_definitions):
 # Creates java or android library targets from maven_hosted .jar/.aar files. This should only
 # be used in build_snippets, as it is no longer the solution that the underlying code generates.
 # All raw_jvm_import properties are passed through.
-def maven_jvm_artifact(artifact, visibility = ["//visibility:public"], **kwargs):
+#
+# For rare cases where the packaging isn't jar, use packaging=. e.g. Guava, which is a "bundle"
+def maven_jvm_artifact(artifact, packaging = "jar", visibility = ["//visibility:public"], **kwargs):
     print("WARNING: maven_jvm_artifact is deprecated, please use raw_jvm_import")
     artifact_struct = artifact_utils.parse_spec(artifact)
-    path = artifact_utils.artifact_path(artifact_struct, "jar")
+    dir = "{group_path}/{artifact_id}/{version}".format(
+        group_path = artifact_struct.group_id.replace(".", "/"),
+        artifact_id = artifact_struct.artifact_id,
+        version = artifact_struct.version
+    )
+    path = "{dir}/maven-{packaging}-{artifact_id}-{version}-classes.{suffix}".format(
+        dir = dir,
+        packaging = packaging,
+        artifact_id = artifact_struct.artifact_id,
+        version = artifact_struct.version,
+        suffix = "jar"
+    )
     file_target = "@%s//%s:%s" % (artifact_utils.fetch_repo(artifact_struct), "maven", path)
     raw_jvm_import(
         visibility = visibility,

--- a/test/test_workspace/build_substitution_templates.bzl
+++ b/test/test_workspace/build_substitution_templates.bzl
@@ -22,7 +22,7 @@ java_library(
 # com.google.dagger:dagger:{version}
 raw_jvm_import(
     name = "dagger-api",
-    jar = "@com_google_dagger_dagger//maven:com/google/dagger/dagger/{version}/dagger-{version}.jar",
+    jar = "@com_google_dagger_dagger//maven:com/google/dagger/dagger/{version}/maven-jar-dagger-{version}-classes.jar",
     deps = [
        "@maven//javax/inject:javax_inject",
     ],


### PR DESCRIPTION
Changes the filename of the jar (main artifact or extracted aar classes), so that IDE integration shows a more unique and useful entry in its external libraries.

Pattern is now `maven-$packaging-$artifactId-$version-classes.jar`

Packaging isn't strictly needed, but it helps to separate .aar from .jar imports. Guava looks a bit weird as maven-bundle-guava-... but it IS a bundle-type. (thanks OSGI and maven)

fixes #117 