### PR TITLE
create subdir too on unzipping artifacts

### DIFF
--- a/kramer/src/main/kotlin/kramer/FetchArtifactCommand.kt
+++ b/kramer/src/main/kotlin/kramer/FetchArtifactCommand.kt
@@ -206,11 +206,14 @@ internal class FetchArtifactCommand : CliktCommand(name = "fetch-artifact") {
           val path = root.resolve(entry.name).normalize()
           if (!path.startsWith(root)) throw IOException("Invalid ZIP")
           if (entry.isDirectory) createDirectories(path)
-          else Files.newOutputStream(path).use { out ->
-            var len: Int
-            val buffer = ByteArray(1024)
-            while (stream.read(buffer).also { len = it } > 0) {
-              out.write(buffer, 0, len)
+          else {
+            createDirectories(path.parent)
+            Files.newOutputStream(path).use { out ->
+              var len: Int
+              val buffer = ByteArray(1024)
+              while (stream.read(buffer).also { len = it } > 0) {
+                out.write(buffer, 0, len)
+              }
             }
           }
           entry = stream.nextEntry

--- a/kramer/src/test/kotlin/kramer/integration/FetchArtifactIntegrationTest.kt
+++ b/kramer/src/test/kotlin/kramer/integration/FetchArtifactIntegrationTest.kt
@@ -101,6 +101,11 @@ class FetchArtifactIntegrationTest {
     assertThat(build).contains("androidx/core/core/1.1.0/core-1.1.0-sources.jar")
   }
 
+  @Test fun testGooglePlay() {
+    val output = cmd.test(flags("com.google.android.gms:play-services-base:17.1.0"), baos)
+    assertThat(output).contains("Fetched com.google.android.gms:play-services-base:17.1.0 insecurely")
+  }
+
   @Test fun testUnavailableArtifact() {
     val output = cmd.fail(flags(artifactSpec = "com.google.noguava:noguava:18.0"), baos)
     assertThat(output).contains("ERROR: Could not resolve com.google.noguava:noguava:18.0!")


### PR DESCRIPTION
fix issue with

```
 Exception in thread "main" java.nio.file.NoSuchFileException: /private/var/tmp/_bazel_rogerh/bca1fc867db017ba7535a1fcbc907dfb/external/com_google_android_gms_play_services_base/maven/res/color/common_google_signin_btn_text_dark.xml
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
	at java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:434)
	at java.nio.file.Files.newOutputStream(Files.java:216)
	at kramer.FetchArtifactCommand.unzip(FetchArtifactCommand.kt:209)
	at kramer.FetchArtifactCommand.run(FetchArtifactCommand.kt:147)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:168)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:176)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:16)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:258)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:255)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:273)
	at kramer.KramerKt.main(Kramer.kt:35)
```