### PR TITLE
Fix a problem where a pom may specify a dependency more than once.

### DIFF
--- a/kramer/src/test/kotlin/kramer/integration/test-duplicate-deps-config.json
+++ b/kramer/src/test/kotlin/kramer/integration/test-duplicate-deps-config.json
@@ -1,0 +1,18 @@
+{
+  "artifacts": {
+    "com.github.jnr:jnr-ffi:2.1.9": { "insecure": true },
+    "org.ow2.asm:asm-tree:5.0.3": {"insecure": true },
+    "com.github.jnr:jnr-x86asm:1.0.2": {"insecure": true },
+    "com.github.jnr:jffi:1.2.17": {"insecure": true },
+    "com.github.jnr:jnr-a64asm:1.0.0": {"insecure": true },
+    "org.ow2.asm:asm-analysis:5.0.3": {"insecure": true },
+    "org.ow2.asm:asm-commons:5.0.3": {"insecure": true },
+    "org.ow2.asm:asm:5.0.3": {"insecure": true },
+    "org.ow2.asm:asm-util:5.0.3": {"insecure": true }
+  },
+  "jetifier_excludes": [],
+  "maven_rules_repository": "maven_repository_rules",
+  "name": "maven",
+  "target_substitutes": {},
+  "use_jetifier": false
+}


### PR DESCRIPTION
Fix a problem where a pom may specify a dependency more than once (e.g. in different scopes). Easily handled by making the dependency an ordered set.

Also add a test case.